### PR TITLE
Openstack extra hdd

### DIFF
--- a/blockstore/pom.xml
+++ b/blockstore/pom.xml
@@ -19,6 +19,26 @@
             <groupId>org.apache.brooklyn</groupId>
             <artifactId>brooklyn-locations-jclouds</artifactId>
             <version>${brooklyn.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.jclouds.api</groupId>
+                    <artifactId>openstack-nova</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.jclouds</groupId>
+                    <artifactId>jclouds-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.cloudsoft.jclouds</groupId>
+            <artifactId>jclouds-core</artifactId>
+            <version>1.9.3-cloudsoft.20160825</version>
+        </dependency>
+        <dependency>
+            <groupId>io.cloudsoft.jclouds.api</groupId>
+            <artifactId>openstack-nova</artifactId>
+            <version>1.9.3-cloudsoft.20160725</version>
         </dependency>
         <dependency>
             <groupId>org.apache.jclouds.api</groupId>

--- a/blockstore/src/main/java/brooklyn/location/blockstore/BlockDeviceOptions.java
+++ b/blockstore/src/main/java/brooklyn/location/blockstore/BlockDeviceOptions.java
@@ -7,6 +7,7 @@ import java.util.Map;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.Maps;
+import org.apache.brooklyn.util.core.flags.TypeCoercions;
 
 public class BlockDeviceOptions {
 
@@ -40,7 +41,7 @@ public class BlockDeviceOptions {
             } else if (map.get("sizeInGb") instanceof Integer){
                 result.sizeInGb = (Integer)map.get("sizeInGb");
             } else {
-                result.sizeInGb = Integer.parseInt((String)map.get("sizeInGb"));
+                result.sizeInGb = TypeCoercions.coerce(map.get("sizeInGb"), Integer.class);
             }
             checkArgument(result.sizeInGb > 0, "sizeInGb should be grater than zero"); 
         } else {

--- a/blockstore/src/main/java/brooklyn/location/blockstore/BlockDeviceOptions.java
+++ b/blockstore/src/main/java/brooklyn/location/blockstore/BlockDeviceOptions.java
@@ -83,6 +83,12 @@ public class BlockDeviceOptions {
         return this;
     }
 
+    /**
+     * @param zone Availability zone for the disk.
+     * @deprecated This is not obtainable from YAML
+     *             and will be overridden to use the same Availability zone as the machine location.
+     */
+    @Deprecated
     public BlockDeviceOptions zone(String zone) {
         this.zone = zone;
         return this;

--- a/blockstore/src/main/java/brooklyn/location/blockstore/BlockDeviceOptions.java
+++ b/blockstore/src/main/java/brooklyn/location/blockstore/BlockDeviceOptions.java
@@ -1,5 +1,6 @@
 package brooklyn.location.blockstore;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Map;
@@ -27,17 +28,24 @@ public class BlockDeviceOptions {
             }
         }
         if (map.containsKey("sizeInGb")) {
+            checkNotNull(map.get("sizeInGb"), "sizeInGb should not be null");
             if (map.get("sizeInGb") instanceof Double && Math.abs((Double) map.get("sizeInGb") - ((Double) map.get("sizeInGb")).intValue()) >= 0.01
                     || map.get("sizeInGb") instanceof Float && Math.abs((Float) map.get("sizeInGb") - ((Float) map.get("sizeInGb")).intValue()) >= 0.01) {
                 throw new UnsupportedOperationException("Trying to set block device with not allowed sizeInGb value "
                         + map.get("sizeInGb") + "; sizeInGb must have integer value.");
             } else if (map.get("sizeInGb") instanceof Double) {
-                result.sizeInGb = checkNotNull(((Double) map.get("sizeInGb")).intValue(), "sizeInGb");
+                result.sizeInGb = ((Double) map.get("sizeInGb")).intValue();
             } else if (map.get("sizeInGb") instanceof Float) {
-                result.sizeInGb = checkNotNull(((Float) map.get("sizeInGb")).intValue(), "sizeInGb");
+                result.sizeInGb = ((Float) map.get("sizeInGb")).intValue();
+            } else if (map.get("sizeInGb") instanceof Integer){
+                result.sizeInGb = (Integer)map.get("sizeInGb");
             } else {
-                result.sizeInGb = (int) checkNotNull(map.get("sizeInGb"), "sizeInGb");
+                result.sizeInGb = Integer.parseInt((String)map.get("sizeInGb"));
             }
+            checkArgument(result.sizeInGb > 0, "sizeInGb should be grater than zero"); 
+        } else {
+            throw new IllegalArgumentException("Tried to create volume with not appropriate parameters "
+                        + map + "; \"blockDevice\" should contain value for \"sizeInGb\"");
         }
         if (map.containsKey("deviceSuffix")) {
             Object val = checkNotNull(map.get("deviceSuffix"), "deviceSuffix");

--- a/blockstore/src/main/java/brooklyn/location/blockstore/NewVolumeCustomizer.java
+++ b/blockstore/src/main/java/brooklyn/location/blockstore/NewVolumeCustomizer.java
@@ -3,25 +3,51 @@ package brooklyn.location.blockstore;
 import brooklyn.location.blockstore.api.MountedBlockDevice;
 import brooklyn.location.blockstore.api.VolumeManager;
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.reflect.TypeToken;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.location.jclouds.BasicJcloudsLocationCustomizer;
+import org.apache.brooklyn.location.jclouds.JcloudsLocation;
 import org.apache.brooklyn.location.jclouds.JcloudsMachineLocation;
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.jclouds.compute.ComputeService;
 import org.jclouds.compute.domain.NodeMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.util.List;
 import java.util.Map;
 
 public abstract class NewVolumeCustomizer extends BasicJcloudsLocationCustomizer {
 
-    public NewVolumeCustomizer(Map<BlockDeviceOptions, FilesystemOptions> volumes) {
-        this.volumes = volumes;
-        this.mountedBlockDevice = null;
+    private static final Logger LOG = LoggerFactory.getLogger(NewVolumeCustomizer.class);
+
+    public static final ConfigKey<List<Map<?, ?>>> VOLUMES = ConfigKeys.newConfigKey(
+            new TypeToken<List<Map<?, ?>>>() {},
+            "volumes", "List of volumes to be attached");
+
+    /**
+     * Used only for checking results from customization
+     */
+    protected transient MountedBlockDevice mountedBlockDevice;
+
+    protected NewVolumeCustomizer() {
     }
 
-    protected Map<BlockDeviceOptions, FilesystemOptions> volumes;
+    public NewVolumeCustomizer(Map<BlockDeviceOptions, FilesystemOptions> volume) {
+        setVolumes(ImmutableList.<Map<?, ?>>of(volume));
+    }
 
-    protected MountedBlockDevice mountedBlockDevice;
-
-    public Map<BlockDeviceOptions, FilesystemOptions> getVolumes() {
-        return volumes;
+    public List<Map<?, ?>> getVolumes() {
+        try {
+            return this.getConfig(VOLUMES);
+        } catch (Exception e) {
+            // We don't want to break execution here but prefer to throw more informative exception
+            // for empty volumes when this method is invoked
+            LOG.warn("Trying to get missing config " + VOLUMES);
+            return ImmutableList.of();
+        }
     }
 
     public MountedBlockDevice getMountedBlockDevice() {
@@ -30,8 +56,55 @@ public abstract class NewVolumeCustomizer extends BasicJcloudsLocationCustomizer
 
     protected abstract VolumeManager getVolumeManager();
 
+    public void setVolumes(List<Map<?, ?>> volumes) {
+        if (volumes == null) {
+            return;
+        }
+        this.config().set(VOLUMES,volumes);
+    }
+
+    public static Map<BlockDeviceOptions, FilesystemOptions> transformMapToVolume(Map<?, ?> map) {
+        if (map.keySet().iterator().next() instanceof BlockDeviceOptions && map.values().iterator().next() instanceof FilesystemOptions) {
+            return (Map<BlockDeviceOptions, FilesystemOptions>) map;
+        }
+
+        if (map.containsKey("blockDevice") && map.containsKey("filesystem")) {
+            BlockDeviceOptions blockDeviceOptions = (map.get("blockDevice") instanceof BlockDeviceOptions) ?
+                    (BlockDeviceOptions) map.get("blockDevice") : BlockDeviceOptions.fromMap((Map<String, ?>) map.get("blockDevice"));
+            if (blockDeviceOptions.getSizeInGb() == 0) {
+                throw new IllegalArgumentException("Tried to create volume with not appropriate parameters "
+                        + map + "; \"blockDevice\" should contain value for \"sizeInGb\"");
+            }
+            FilesystemOptions filesystemOptions = (map.get("filesystem") instanceof FilesystemOptions) ?
+                    (FilesystemOptions) map.get("filesystem") : FilesystemOptions.fromMap((Map<String, ?>) map.get("filesystem"));
+            Map<BlockDeviceOptions, FilesystemOptions> locationCustomizerFields = MutableMap.of(
+                    blockDeviceOptions,
+                    filesystemOptions
+            );
+
+            return locationCustomizerFields;
+        } else {
+            throw new IllegalArgumentException("Tried to create volume with not appropriate parameters. " +
+                    "Expected parameter of type { \"blockDevice\": {}, \"filesystem\": {} }, but found " + map);
+        }
+    }
+
+    public void customize(JcloudsLocation location, ComputeService computeService, JcloudsMachineLocation machine) {
+        if (!getVolumes().isEmpty()) {
+            createAndAttachDisks(machine);
+        } else {
+            throw new UnsupportedOperationException("There is no volume data populated to create and attach disk.");
+        }
+    }
+
     protected void createAndAttachDisks(JcloudsMachineLocation machine) {
-        for (Map.Entry<BlockDeviceOptions, FilesystemOptions> entry : volumes.entrySet()) {
+        for (Map<?, ?> volume : getVolumes()) {
+            createAndAttachDisk(machine, transformMapToVolume(volume));
+        }
+    }
+
+    protected void createAndAttachDisk(JcloudsMachineLocation machine, Map<BlockDeviceOptions, FilesystemOptions> volume) {
+        for (Map.Entry<BlockDeviceOptions, FilesystemOptions> entry : volume.entrySet()) {
             BlockDeviceOptions blockOptions = entry.getKey();
             FilesystemOptions filesystemOptions = entry.getValue();
             if (filesystemOptions != null) {

--- a/blockstore/src/main/java/brooklyn/location/blockstore/NewVolumeCustomizer.java
+++ b/blockstore/src/main/java/brooklyn/location/blockstore/NewVolumeCustomizer.java
@@ -13,10 +13,13 @@ import org.apache.brooklyn.location.jclouds.JcloudsMachineLocation;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.jclouds.compute.ComputeService;
 import org.jclouds.compute.domain.NodeMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
 public abstract class NewVolumeCustomizer extends BasicJcloudsLocationCustomizer {
+    private static final Logger LOG = LoggerFactory.getLogger(NewVolumeCustomizer.class);
 
     public static final ConfigKey<List<VolumeOptions>> VOLUMES = ConfigKeys.newConfigKey(
             new TypeToken<List<VolumeOptions>>() {},
@@ -70,6 +73,8 @@ public abstract class NewVolumeCustomizer extends BasicJcloudsLocationCustomizer
             Optional<NodeMetadata> node = machine.getOptionalNode();
             if (node.isPresent()) {
                 blockOptionsCopy.zone(node.get().getLocation().getId());
+            } else {
+                LOG.warn("JcloudsNodeMetadata is not available for the MachineLocation. Using zone specified from a parameter.");
             }
             mountedBlockDeviceList.add(getVolumeManager().createAttachAndMountVolume(machine, blockOptionsCopy, volumeOptions.getFilesystemOptions()));
         }

--- a/blockstore/src/main/java/brooklyn/location/blockstore/NewVolumeCustomizer.java
+++ b/blockstore/src/main/java/brooklyn/location/blockstore/NewVolumeCustomizer.java
@@ -2,9 +2,8 @@ package brooklyn.location.blockstore;
 
 import brooklyn.location.blockstore.api.MountedBlockDevice;
 import brooklyn.location.blockstore.api.VolumeManager;
-import com.google.common.annotations.VisibleForTesting;
+import brooklyn.location.blockstore.api.VolumeOptions;
 import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
 import com.google.common.reflect.TypeToken;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
@@ -12,18 +11,16 @@ import org.apache.brooklyn.location.jclouds.BasicJcloudsLocationCustomizer;
 import org.apache.brooklyn.location.jclouds.JcloudsLocation;
 import org.apache.brooklyn.location.jclouds.JcloudsMachineLocation;
 import org.apache.brooklyn.util.collections.MutableList;
-import org.apache.brooklyn.util.collections.MutableMap;
 import org.jclouds.compute.ComputeService;
 import org.jclouds.compute.domain.NodeMetadata;
 
 import java.util.List;
-import java.util.Map;
 
 public abstract class NewVolumeCustomizer extends BasicJcloudsLocationCustomizer {
 
-    public static final ConfigKey<List<Map<?, ?>>> VOLUMES = ConfigKeys.newConfigKey(
-            new TypeToken<List<Map<?, ?>>>() {},
-            "volumes", "List of volumes to be attached", ImmutableList.<Map<?, ?>>of());
+    public static final ConfigKey<List<VolumeOptions>> VOLUMES = ConfigKeys.newConfigKey(
+            new TypeToken<List<VolumeOptions>>() {},
+            "volumes", "List of volumes to be attached");
 
     /**
      * Used only for checking results from customization
@@ -34,21 +31,13 @@ public abstract class NewVolumeCustomizer extends BasicJcloudsLocationCustomizer
         mountedBlockDeviceList = MutableList.of();
     }
 
-    public NewVolumeCustomizer(Map<?, ?> volume) {
-        setVolumes(ImmutableList.<Map<?, ?>>of(volume));
+    public NewVolumeCustomizer(List<VolumeOptions> volumesOptions) {
+        this.config().set(VOLUMES, volumesOptions);
         mountedBlockDeviceList = MutableList.of();
     }
 
-    public List<Map<?, ?>> getVolumes() {
+    public List<VolumeOptions> getVolumes() {
         return this.getConfig(VOLUMES);
-    }
-
-    public List<Map<BlockDeviceOptions, FilesystemOptions>> getParsedVolumes() {
-        List<Map<BlockDeviceOptions, FilesystemOptions>> parsedVolumes = MutableList.of();
-        for (Map<?, ?> volume: this.getConfig(VOLUMES)) {
-            parsedVolumes.add(transformMapToVolume(volume));
-        }
-        return parsedVolumes;
     }
 
     public List<MountedBlockDevice> getMountedBlockDeviceList() {
@@ -57,34 +46,8 @@ public abstract class NewVolumeCustomizer extends BasicJcloudsLocationCustomizer
 
     protected abstract VolumeManager getVolumeManager();
 
-    public void setVolumes(List<Map<?, ?>> volumes) {
-        if (volumes == null) {
-            return;
-        }
+    public void setVolumes(List<VolumeOptions> volumes) {
         this.config().set(VOLUMES,volumes);
-    }
-
-    @VisibleForTesting
-    public static Map<BlockDeviceOptions, FilesystemOptions> transformMapToVolume(Map<?, ?> map) {
-        if (map.containsKey("blockDevice") && map.containsKey("filesystem")) {
-            BlockDeviceOptions blockDeviceOptions = (map.get("blockDevice") instanceof BlockDeviceOptions) ?
-                    (BlockDeviceOptions) map.get("blockDevice") : BlockDeviceOptions.fromMap((Map<String, ?>) map.get("blockDevice"));
-            if (blockDeviceOptions.getSizeInGb() == 0) {
-                throw new IllegalArgumentException("Tried to create volume with not appropriate parameters "
-                        + map + "; \"blockDevice\" should contain value for \"sizeInGb\"");
-            }
-            FilesystemOptions filesystemOptions = (map.get("filesystem") instanceof FilesystemOptions) ?
-                    (FilesystemOptions) map.get("filesystem") : FilesystemOptions.fromMap((Map<String, ?>) map.get("filesystem"));
-            Map<BlockDeviceOptions, FilesystemOptions> locationCustomizerFields = MutableMap.of(
-                    blockDeviceOptions,
-                    filesystemOptions
-            );
-
-            return locationCustomizerFields;
-        } else {
-            throw new IllegalArgumentException("Tried to create volume with not appropriate parameters. " +
-                    "Expected parameter of type { \"blockDevice\": {}, \"filesystem\": {} }, but found " + map);
-        }
     }
 
     public void customize(JcloudsLocation location, ComputeService computeService, JcloudsMachineLocation machine) {
@@ -96,23 +59,19 @@ public abstract class NewVolumeCustomizer extends BasicJcloudsLocationCustomizer
     }
 
     protected void createAndAttachDisks(JcloudsMachineLocation machine) {
-        for (Map<?, ?> volume : getVolumes()) {
-            createAndAttachDisk(machine, transformMapToVolume(volume));
+        for (VolumeOptions volume : getVolumes()) {
+            createAndAttachDisk(machine, volume);
         }
     }
 
-    protected void createAndAttachDisk(JcloudsMachineLocation machine, Map<BlockDeviceOptions, FilesystemOptions> volume) {
-        for (Map.Entry<BlockDeviceOptions, FilesystemOptions> entry : volume.entrySet()) {
-            BlockDeviceOptions blockOptions = entry.getKey();
-            FilesystemOptions filesystemOptions = entry.getValue();
-            if (filesystemOptions != null) {
-                BlockDeviceOptions blockOptionsCopy = BlockDeviceOptions.copy(blockOptions);
-                Optional<NodeMetadata> node = machine.getOptionalNode();
-                if (node.isPresent()) {
-                    blockOptionsCopy.zone(node.get().getLocation().getId());
-                }
-                mountedBlockDeviceList.add(getVolumeManager().createAttachAndMountVolume(machine, blockOptionsCopy, filesystemOptions));
+    protected void createAndAttachDisk(JcloudsMachineLocation machine, VolumeOptions volumeOptions) {
+        if (volumeOptions.getFilesystemOptions() != null) {
+            BlockDeviceOptions blockOptionsCopy = BlockDeviceOptions.copy(volumeOptions.getBlockDeviceOptions());
+            Optional<NodeMetadata> node = machine.getOptionalNode();
+            if (node.isPresent()) {
+                blockOptionsCopy.zone(node.get().getLocation().getId());
             }
+            mountedBlockDeviceList.add(getVolumeManager().createAttachAndMountVolume(machine, blockOptionsCopy, volumeOptions.getFilesystemOptions()));
         }
     }
 }

--- a/blockstore/src/main/java/brooklyn/location/blockstore/NewVolumeCustomizer.java
+++ b/blockstore/src/main/java/brooklyn/location/blockstore/NewVolumeCustomizer.java
@@ -10,13 +10,23 @@ import org.jclouds.compute.domain.NodeMetadata;
 import java.util.Map;
 
 public abstract class NewVolumeCustomizer extends BasicJcloudsLocationCustomizer {
+
+    public NewVolumeCustomizer(Map<BlockDeviceOptions, FilesystemOptions> volumes) {
+        this.volumes = volumes;
+        this.mountedBlockDevice = null;
+    }
+
     protected Map<BlockDeviceOptions, FilesystemOptions> volumes;
 
     protected MountedBlockDevice mountedBlockDevice;
 
-    public abstract Map<BlockDeviceOptions, FilesystemOptions> getVolumes();
+    public Map<BlockDeviceOptions, FilesystemOptions> getVolumes() {
+        return volumes;
+    }
 
-    public abstract MountedBlockDevice getMountedBlockDevice();
+    public MountedBlockDevice getMountedBlockDevice() {
+        return mountedBlockDevice;
+    }
 
     protected abstract VolumeManager getVolumeManager();
 

--- a/blockstore/src/main/java/brooklyn/location/blockstore/api/VolumeOptions.java
+++ b/blockstore/src/main/java/brooklyn/location/blockstore/api/VolumeOptions.java
@@ -1,0 +1,46 @@
+package brooklyn.location.blockstore.api;
+
+import brooklyn.location.blockstore.BlockDeviceOptions;
+import brooklyn.location.blockstore.FilesystemOptions;
+import org.apache.brooklyn.util.core.flags.TypeCoercions;
+
+import java.util.Map;
+
+public class VolumeOptions {
+    private BlockDeviceOptions blockDeviceOptions;
+    private FilesystemOptions filesystemOptions;
+
+    public static VolumeOptions fromString(String map) {
+        return fromMap(TypeCoercions.coerce(map, Map.class));
+    }
+
+    public static VolumeOptions fromMap(Map<String, Map<String, ?>> map) {
+        if (map.containsKey("blockDevice") && (map.containsKey("filesystem") || map.containsKey("fileSystem"))) {
+            BlockDeviceOptions blockDeviceOptions = BlockDeviceOptions.fromMap(map.get("blockDevice"));
+            FilesystemOptions filesystemOptions = FilesystemOptions.fromMap(map.get("filesystem") != null ? map.get("filesystem") : map.get("fileSystem"));
+            VolumeOptions volumeOptions = new VolumeOptions(blockDeviceOptions, filesystemOptions);
+            return volumeOptions;
+        } else {
+            throw new IllegalArgumentException("Tried to create volume with not appropriate parameters. " +
+                    "Expected parameter of type { \"blockDevice\": {}, \"filesystem\": {} }, but found " + map);
+        }
+    }
+
+    public VolumeOptions(BlockDeviceOptions blockDeviceOptions, FilesystemOptions filesystemOptions) {
+        this.blockDeviceOptions = blockDeviceOptions;
+        this.filesystemOptions = filesystemOptions;
+    }
+
+    public BlockDeviceOptions getBlockDeviceOptions() {
+        return blockDeviceOptions;
+    }
+
+    public FilesystemOptions getFilesystemOptions() {
+        return filesystemOptions;
+    }
+
+    @Override
+    public String toString() {
+        return "{blockDeviceOptions: " + blockDeviceOptions + ", filesystemOptions: " + filesystemOptions + "}";
+    }
+}

--- a/blockstore/src/main/java/brooklyn/location/blockstore/ec2/Ec2NewVolumeCustomizer.java
+++ b/blockstore/src/main/java/brooklyn/location/blockstore/ec2/Ec2NewVolumeCustomizer.java
@@ -4,7 +4,6 @@ import brooklyn.location.blockstore.BlockDeviceOptions;
 import brooklyn.location.blockstore.FilesystemOptions;
 import brooklyn.location.blockstore.NewVolumeCustomizer;
 import brooklyn.location.blockstore.api.VolumeManager;
-import org.apache.brooklyn.util.core.config.ConfigBag;
 
 import java.util.Map;
 
@@ -23,7 +22,7 @@ import java.util.Map;
  *   provisioning.properties:
  *     customizers:
  *     - $brooklyn:object:
- *         type: brooklyn.location.blockstore.ec2.Ec2NewVolumeCustomizer
+ *         type: io.brooklyn.blockstore.brooklyn-blockstore:brooklyn.location.blockstore.ec2.Ec2NewVolumeCustomizer
  *         brooklyn.config:
  *           volumes:
  *           - blockDevice:

--- a/blockstore/src/main/java/brooklyn/location/blockstore/ec2/Ec2NewVolumeCustomizer.java
+++ b/blockstore/src/main/java/brooklyn/location/blockstore/ec2/Ec2NewVolumeCustomizer.java
@@ -2,8 +2,9 @@ package brooklyn.location.blockstore.ec2;
 
 import brooklyn.location.blockstore.NewVolumeCustomizer;
 import brooklyn.location.blockstore.api.VolumeManager;
+import brooklyn.location.blockstore.api.VolumeOptions;
 
-import java.util.Map;
+import java.util.List;
 
 /**
  * Creates a location customizer that:
@@ -40,8 +41,8 @@ public class Ec2NewVolumeCustomizer extends NewVolumeCustomizer {
         // for reflective creation (e.g. with $brooklyn:object)
     }
 
-    public Ec2NewVolumeCustomizer(Map<?, ?> volume) {
-        super(volume);
+    public Ec2NewVolumeCustomizer(List<VolumeOptions> volumes) {
+        super(volumes);
     }
 
     @Override

--- a/blockstore/src/main/java/brooklyn/location/blockstore/ec2/Ec2NewVolumeCustomizer.java
+++ b/blockstore/src/main/java/brooklyn/location/blockstore/ec2/Ec2NewVolumeCustomizer.java
@@ -1,22 +1,12 @@
 package brooklyn.location.blockstore.ec2;
 
-import java.util.List;
-import java.util.Map;
-
-import org.apache.brooklyn.location.jclouds.BasicJcloudsLocationCustomizer;
-import org.apache.brooklyn.location.jclouds.JcloudsLocation;
-import org.apache.brooklyn.location.jclouds.JcloudsMachineLocation;
-import org.jclouds.compute.ComputeService;
-import org.jclouds.compute.domain.NodeMetadata;
-import org.jclouds.compute.domain.TemplateBuilder;
-
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Optional;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Maps;
-
 import brooklyn.location.blockstore.BlockDeviceOptions;
 import brooklyn.location.blockstore.FilesystemOptions;
+import brooklyn.location.blockstore.NewVolumeCustomizer;
+import brooklyn.location.blockstore.api.VolumeManager;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+
+import java.util.Map;
 
 /**
  * Creates a location customizer that:
@@ -25,81 +15,40 @@ import brooklyn.location.blockstore.FilesystemOptions;
  * <li>attaches the specified (existing) volume to the newly-provisioned EC2 instance</li>
  * <li>mounts the filesystem under the requested path</li>
  * </ul>
+ *
+ * Can be used for attaching additional disk on provisioning time for AWS.
+ * Below is shown an example:
+ *
+ * <pre>
+ *   provisioning.properties:
+ *     customizers:
+ *     - $brooklyn:object:
+ *         type: brooklyn.location.blockstore.ec2.Ec2NewVolumeCustomizer
+ *         brooklyn.config:
+ *           volumes:
+ *           - blockDevice:
+ *               sizeInGb: 3
+ *               deviceSuffix: 'h'
+ *               deleteOnTermination: true
+ *               tags:
+ *                 brooklyn: br-example-test-1
+ *            filesystem:
+ *              mountPoint: /mount/brooklyn/h
+ *              filesystemType: ext3
+ * </pre>
  */
-public class Ec2NewVolumeCustomizer extends BasicJcloudsLocationCustomizer {
+public class Ec2NewVolumeCustomizer extends NewVolumeCustomizer {
 
-    private static final Ec2VolumeManager ebsVolumeManager = new Ec2VolumeManager();
-
-//    // For simpler yaml usage
-//    private List<Map<String,?>> volumes;
-//
-    private Map<BlockDeviceOptions, FilesystemOptions> _volumes;
-    
-    public Ec2NewVolumeCustomizer(Map<BlockDeviceOptions, FilesystemOptions> volumes) {
-        this._volumes = volumes;
-    }
-    
     public Ec2NewVolumeCustomizer() {
         // for reflective creation (e.g. with $brooklyn:object)
     }
-    
-    @SuppressWarnings("unchecked")
-    public void setVolumes(List<Map<String, ?>> val) {
-        _volumes = Maps.newLinkedHashMap();
-        if (val == null) {
-            return;
-        }
-        for (Map<String,?> volume : val) {
-            BlockDeviceOptions bdOptions;
-            FilesystemOptions fsOptions;
-            Object blockDevice = volume.get("blockDevice");
-            if (blockDevice instanceof Map<?,?>) {
-                bdOptions = BlockDeviceOptions.fromMap((Map<String, ?>) blockDevice);
-            } else if (blockDevice instanceof BlockDeviceOptions) {
-                bdOptions = (BlockDeviceOptions) blockDevice;
-            } else {
-                throw new IllegalArgumentException("Invalid blockDevice "+blockDevice+ (blockDevice == null ? "" : " of type "+blockDevice.getClass().getName()));
-            }
-            
-            Object filesystem = volume.get("filesystem");
-            if (filesystem instanceof Map<?,?>) {
-                fsOptions = FilesystemOptions.fromMap((Map<String, ?>) filesystem);
-            } else if (filesystem instanceof FilesystemOptions) {
-                fsOptions = (FilesystemOptions) filesystem;
-            } else {
-                throw new IllegalArgumentException("Invalid filesystem "+filesystem+ (filesystem == null ? "" : " of type "+filesystem.getClass().getName()));
-            }
-            
-            _volumes.put(bdOptions, fsOptions);
-        }
-    }
-    
-    @VisibleForTesting
-    public Map<BlockDeviceOptions, FilesystemOptions> getParsedVolumes() {
-        return _volumes;
-    }
-    
-    @Override
-    public void customize(JcloudsLocation location, ComputeService computeService, TemplateBuilder templateBuilder) {
-        BlockDeviceOptions blockOptions = Iterables.getFirst(_volumes.keySet(), null);
-        if (blockOptions != null && blockOptions.getZone() != null) {
-            templateBuilder.locationId(blockOptions.getZone());
-        }
+
+    public Ec2NewVolumeCustomizer(Map<BlockDeviceOptions, FilesystemOptions> volume) {
+        super(volume);
     }
 
     @Override
-    public void customize(JcloudsLocation location, ComputeService computeService, JcloudsMachineLocation machine) {
-        for (Map.Entry<BlockDeviceOptions, FilesystemOptions> entry : _volumes.entrySet()) {
-            BlockDeviceOptions blockDeviceOptions = entry.getKey();
-            FilesystemOptions filesystemOptions = entry.getValue();
-            
-            BlockDeviceOptions blockDeviceOptionsCopy = BlockDeviceOptions.copy(blockDeviceOptions);
-            Optional<NodeMetadata> node = machine.getOptionalNode();
-            if (node.isPresent()) {
-                blockDeviceOptionsCopy.zone(node.get().getLocation().getId());
-            }
-
-            ebsVolumeManager.createAttachAndMountVolume(machine, blockDeviceOptionsCopy, filesystemOptions);
-        }
+    protected VolumeManager getVolumeManager() {
+        return new Ec2VolumeManager();
     }
 }

--- a/blockstore/src/main/java/brooklyn/location/blockstore/ec2/Ec2NewVolumeCustomizer.java
+++ b/blockstore/src/main/java/brooklyn/location/blockstore/ec2/Ec2NewVolumeCustomizer.java
@@ -1,7 +1,5 @@
 package brooklyn.location.blockstore.ec2;
 
-import brooklyn.location.blockstore.BlockDeviceOptions;
-import brooklyn.location.blockstore.FilesystemOptions;
 import brooklyn.location.blockstore.NewVolumeCustomizer;
 import brooklyn.location.blockstore.api.VolumeManager;
 
@@ -42,7 +40,7 @@ public class Ec2NewVolumeCustomizer extends NewVolumeCustomizer {
         // for reflective creation (e.g. with $brooklyn:object)
     }
 
-    public Ec2NewVolumeCustomizer(Map<BlockDeviceOptions, FilesystemOptions> volume) {
+    public Ec2NewVolumeCustomizer(Map<?, ?> volume) {
         super(volume);
     }
 

--- a/blockstore/src/main/java/brooklyn/location/blockstore/ec2/Ec2VolumeCustomizers.java
+++ b/blockstore/src/main/java/brooklyn/location/blockstore/ec2/Ec2VolumeCustomizers.java
@@ -73,18 +73,7 @@ public class Ec2VolumeCustomizers {
 
     public static class NewVolumeCustomizer extends brooklyn.location.blockstore.NewVolumeCustomizer {
         public NewVolumeCustomizer(Map<BlockDeviceOptions, FilesystemOptions> volumes) {
-            this.volumes = volumes;
-            this.mountedBlockDevice = null;
-        }
-
-        @Override
-        public Map<BlockDeviceOptions, FilesystemOptions> getVolumes() {
-            return volumes;
-        }
-
-        @Override
-        public MountedBlockDevice getMountedBlockDevice() {
-            return mountedBlockDevice;
+            super(volumes);
         }
 
         @Override

--- a/blockstore/src/main/java/brooklyn/location/blockstore/effectors/ExtraHddBodyEffector.java
+++ b/blockstore/src/main/java/brooklyn/location/blockstore/effectors/ExtraHddBodyEffector.java
@@ -2,9 +2,11 @@ package brooklyn.location.blockstore.effectors;
 
 import brooklyn.location.blockstore.NewVolumeCustomizer;
 import brooklyn.location.blockstore.api.MountedBlockDevice;
+import brooklyn.location.blockstore.api.VolumeOptions;
 import brooklyn.location.blockstore.ec2.Ec2NewVolumeCustomizer;
 import brooklyn.location.blockstore.openstack.OpenstackNewVolumeCustomizer;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.reflect.TypeToken;
 import org.apache.brooklyn.api.entity.EntityLocal;
@@ -16,13 +18,11 @@ import org.apache.brooklyn.core.effector.EffectorTasks;
 import org.apache.brooklyn.core.effector.Effectors;
 import org.apache.brooklyn.location.jclouds.JcloudsLocationCustomizer;
 import org.apache.brooklyn.location.jclouds.JcloudsMachineLocation;
-import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.config.ConfigBag;
-import org.apache.brooklyn.util.core.flags.TypeCoercions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Map;
+import java.util.List;
 
 /**
  * Effector for attaching disks during runtime.
@@ -60,8 +60,9 @@ public class ExtraHddBodyEffector extends AddEffector {
 
     private static final Logger LOG = LoggerFactory.getLogger(ExtraHddBodyEffector.class);
 
-    static ConfigKey<Map<?,?>> LOCATION_CUSTOMIZER_FIELDS = ConfigKeys.newConfigKey(new TypeToken<Map<?,?>>() {}, "location.customizer.fields",
-            "Map of location customizer fields.", MutableMap.of());
+    static ConfigKey<VolumeOptions> LOCATION_CUSTOMIZER_FIELDS = ConfigKeys.newConfigKey(
+            new TypeToken<VolumeOptions>() {}, "location.customizer.fields",
+            "Map of location customizer fields.");
 
     public static final String EXTRA_HDD_EFFECTOR_NAME = "addExtraHdd";
     public static final String AWS_CLOUD = "aws-ec2";
@@ -94,16 +95,16 @@ public class ExtraHddBodyEffector extends AddEffector {
         @Override
         public MountedBlockDevice call(ConfigBag parameters) {
             Preconditions.checkNotNull(parameters.get(LOCATION_CUSTOMIZER_FIELDS), LOCATION_CUSTOMIZER_FIELDS.getName() + " is required");
-            Map<?, ?> locationCustomizerFields = TypeCoercions.coerce(parameters.get(LOCATION_CUSTOMIZER_FIELDS), Map.class);
+            VolumeOptions volumeOptions = parameters.get(LOCATION_CUSTOMIZER_FIELDS);
 
             JcloudsMachineLocation machine = EffectorTasks.getMachine(entity(), JcloudsMachineLocation.class);
             String provider = machine.getParent().getProvider();
 
             LOG.info("Invoking effector addExtraHdd for cloud "+ provider + " on entity " + entity());
 
-            LOG.info("Invoking effector " + EXTRA_HDD_EFFECTOR_NAME + " with location customizer fields " + locationCustomizerFields);
+            LOG.info("Invoking effector " + EXTRA_HDD_EFFECTOR_NAME + " with location customizer fields " + volumeOptions);
 
-            NewVolumeCustomizer customizer = getCustomizerForCloud(provider, locationCustomizerFields);
+            NewVolumeCustomizer customizer = getCustomizerForCloud(provider, ImmutableList.of(volumeOptions));
             customizer.customize(machine.getParent(), machine.getParent().getComputeService(), machine);
 
             if (customizer.getMountedBlockDeviceList().isEmpty()) {
@@ -113,7 +114,7 @@ public class ExtraHddBodyEffector extends AddEffector {
             return Iterables.getLast(customizer.getMountedBlockDeviceList());
         }
 
-        private NewVolumeCustomizer getCustomizerForCloud(String provider, Map<?, ?> locationCustomizerFields) {
+        private NewVolumeCustomizer getCustomizerForCloud(String provider, List<VolumeOptions> locationCustomizerFields) {
             JcloudsLocationCustomizer customizer;
 
             switch (provider) {

--- a/blockstore/src/main/java/brooklyn/location/blockstore/effectors/ExtraHddBodyEffector.java
+++ b/blockstore/src/main/java/brooklyn/location/blockstore/effectors/ExtraHddBodyEffector.java
@@ -30,7 +30,7 @@ import java.util.Map;
  * To attach the effector you should apply the following initializer with different type reference than the one for the non-karaf version - notice that Bundle-SymbolicName is added as a prefix:
  * <pre>
  *    brooklyn.initializers:
- *     - type: io.cloudsoft.amp.vm-customization:io.cloudsoft.amp.vmcustomization.ExtraHddBodyEffector
+ *     - type: io.brooklyn.blockstore.brooklyn-blockstore:brooklyn.location.blockstore.effectors.ExtraHddBodyEffector
  * </pre>
  *
  * The expected effector argument value is json map applicable to Ec2NewVolumeCustomizer's fileds.<br>

--- a/blockstore/src/main/java/brooklyn/location/blockstore/effectors/ExtraHddBodyEffector.java
+++ b/blockstore/src/main/java/brooklyn/location/blockstore/effectors/ExtraHddBodyEffector.java
@@ -42,7 +42,7 @@ import java.util.Map;
  *        "deviceSuffix": 'h',
  *        "deleteOnTermination": false,
  *        "tags": {
- *          "brooklyn": "br-example-val-test-1"
+ *          "brooklyn": "br-example-test-1"
  *        }
  *      },
  *      "filesystem": {

--- a/blockstore/src/main/java/brooklyn/location/blockstore/effectors/ExtraHddBodyEffector.java
+++ b/blockstore/src/main/java/brooklyn/location/blockstore/effectors/ExtraHddBodyEffector.java
@@ -38,7 +38,7 @@ import java.util.Map;
  *    {
  *      "blockDevice": {
  *        "sizeInGb": 3,
- *        "deviceSuffix": "h",
+ *        "deviceSuffix": 'h',
  *        "deleteOnTermination": false,
  *        "tags": {
  *          "brooklyn": "br-example-val-test-1"
@@ -50,6 +50,11 @@ import java.util.Map;
  *      }
  *    }
  * </pre>
+ *
+ * Important notice is that KVM is configured as the default hypervisor for OpenStack which means that the defined device name will be of type /dev/vd*.
+ * This means that the device suffix must be set as the next letter in alphabetical order from the existing device names on the VM.
+ * In other words, "deviceSuffix" have to be set to 'b', 'c' and etc. depending on the already available device names.
+ *
  */
 public class ExtraHddBodyEffector extends AddEffector {
 

--- a/blockstore/src/main/java/brooklyn/location/blockstore/openstack/AbstractOpenstackVolumeManager.java
+++ b/blockstore/src/main/java/brooklyn/location/blockstore/openstack/AbstractOpenstackVolumeManager.java
@@ -26,7 +26,7 @@ public abstract class AbstractOpenstackVolumeManager extends AbstractVolumeManag
 
     private static final Logger LOG = LoggerFactory.getLogger(AbstractOpenstackVolumeManager.class);
     private static final String DEVICE_PREFIX = "/dev/sd";
-    private static final String OS_DEVICE_PREFIX = "/dev/xvd";
+    private static final String OS_DEVICE_PREFIX = "/dev/vd";
 
     protected abstract CinderApi getCinderApi(JcloudsLocation location);
 

--- a/blockstore/src/main/java/brooklyn/location/blockstore/openstack/OpenstackNewVolumeCustomizer.java
+++ b/blockstore/src/main/java/brooklyn/location/blockstore/openstack/OpenstackNewVolumeCustomizer.java
@@ -1,0 +1,92 @@
+package brooklyn.location.blockstore.openstack;
+
+import brooklyn.location.blockstore.BlockDeviceOptions;
+import brooklyn.location.blockstore.FilesystemOptions;
+import brooklyn.location.blockstore.api.MountedBlockDevice;
+import brooklyn.location.blockstore.api.VolumeManager;
+import com.google.common.base.Optional;
+import com.google.common.collect.Maps;
+import org.apache.brooklyn.location.jclouds.BasicJcloudsLocationCustomizer;
+import org.apache.brooklyn.location.jclouds.JcloudsLocation;
+import org.apache.brooklyn.location.jclouds.JcloudsMachineLocation;
+import org.jclouds.compute.ComputeService;
+import org.jclouds.compute.domain.NodeMetadata;
+
+import java.util.List;
+import java.util.Map;
+
+public class OpenstackNewVolumeCustomizer extends BasicJcloudsLocationCustomizer {
+
+    private static final OpenstackVolumeManager openstackVolumeManager = new OpenstackVolumeManager();
+
+    private Map<BlockDeviceOptions, FilesystemOptions> volumes;
+
+    protected MountedBlockDevice mountedBlockDevice;
+
+    public OpenstackNewVolumeCustomizer(Map<BlockDeviceOptions, FilesystemOptions> volumes) {
+        this.volumes = volumes;
+        this.mountedBlockDevice = null;
+    }
+
+    public OpenstackNewVolumeCustomizer() {
+        // for reflective creation (e.g. with $brooklyn:object)
+    }
+
+    protected VolumeManager getVolumeManager() {
+        return new OpenstackVolumeManager();
+    }
+
+    public MountedBlockDevice getMountedBlockDevice() {
+        return mountedBlockDevice;
+    }
+
+    @SuppressWarnings("unchecked")
+    public void setVolumes(List<Map<String, ?>> val) {
+        volumes = Maps.newLinkedHashMap();
+        if (val == null) {
+            return;
+        }
+        for (Map<String,?> volume : val) {
+            BlockDeviceOptions bdOptions;
+            FilesystemOptions fsOptions;
+            Object blockDevice = volume.get("blockDevice");
+            if (blockDevice instanceof Map<?,?>) {
+                bdOptions = BlockDeviceOptions.fromMap((Map<String, ?>) blockDevice);
+            } else if (blockDevice instanceof BlockDeviceOptions) {
+                bdOptions = (BlockDeviceOptions) blockDevice;
+            } else {
+                throw new IllegalArgumentException("Invalid blockDevice "+blockDevice+ (blockDevice == null ? "" : " of type "+blockDevice.getClass().getName()));
+            }
+
+            Object filesystem = volume.get("filesystem");
+            if (filesystem instanceof Map<?,?>) {
+                fsOptions = FilesystemOptions.fromMap((Map<String, ?>) filesystem);
+            } else if (filesystem instanceof FilesystemOptions) {
+                fsOptions = (FilesystemOptions) filesystem;
+            } else {
+                throw new IllegalArgumentException("Invalid filesystem "+filesystem+ (filesystem == null ? "" : " of type "+filesystem.getClass().getName()));
+            }
+
+            volumes.put(bdOptions, fsOptions);
+        }
+    }
+
+    public void customize(JcloudsLocation location, ComputeService computeService, JcloudsMachineLocation machine) {
+        createAndAttachDisks(machine);
+    }
+
+    protected void createAndAttachDisks(JcloudsMachineLocation machine) {
+        for (Map.Entry<BlockDeviceOptions, FilesystemOptions> entry : volumes.entrySet()) {
+            BlockDeviceOptions blockOptions = entry.getKey();
+            FilesystemOptions filesystemOptions = entry.getValue();
+            if (filesystemOptions != null) {
+                BlockDeviceOptions blockOptionsCopy = BlockDeviceOptions.copy(blockOptions);
+                Optional<NodeMetadata> node = machine.getOptionalNode();
+                if (node.isPresent()) {
+                    blockOptionsCopy.zone(node.get().getLocation().getId());
+                }
+                mountedBlockDevice = openstackVolumeManager.createAttachAndMountVolume(machine, blockOptionsCopy, filesystemOptions);
+            }
+        }
+    }
+}

--- a/blockstore/src/main/java/brooklyn/location/blockstore/openstack/OpenstackNewVolumeCustomizer.java
+++ b/blockstore/src/main/java/brooklyn/location/blockstore/openstack/OpenstackNewVolumeCustomizer.java
@@ -16,7 +16,7 @@ import java.util.Map;
  *   provisioning.properties:
  *     customizers:
  *     - $brooklyn:object:
- *         type: brooklyn.location.blockstore.openstack.OpenstackNewVolumeCustomizer
+ *         type: io.brooklyn.blockstore.brooklyn-blockstore:brooklyn.location.blockstore.openstack.OpenstackNewVolumeCustomizer
  *         brooklyn.config:
  *           volumes:
  *           - blockDevice:

--- a/blockstore/src/main/java/brooklyn/location/blockstore/openstack/OpenstackNewVolumeCustomizer.java
+++ b/blockstore/src/main/java/brooklyn/location/blockstore/openstack/OpenstackNewVolumeCustomizer.java
@@ -2,7 +2,9 @@ package brooklyn.location.blockstore.openstack;
 
 import brooklyn.location.blockstore.NewVolumeCustomizer;
 import brooklyn.location.blockstore.api.VolumeManager;
+import brooklyn.location.blockstore.api.VolumeOptions;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -38,7 +40,7 @@ public class OpenstackNewVolumeCustomizer extends NewVolumeCustomizer {
         // for reflective creation (e.g. with $brooklyn:object)
     }
 
-    public OpenstackNewVolumeCustomizer(Map<?, ?> volume) {
+    public OpenstackNewVolumeCustomizer(List<VolumeOptions> volume) {
         super(volume);
     }
 

--- a/blockstore/src/main/java/brooklyn/location/blockstore/openstack/OpenstackNewVolumeCustomizer.java
+++ b/blockstore/src/main/java/brooklyn/location/blockstore/openstack/OpenstackNewVolumeCustomizer.java
@@ -15,6 +15,33 @@ import org.jclouds.compute.domain.NodeMetadata;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Customizer that can be used for attaching additional disk on provisioning time for OpenStack.<br><br>
+ *
+ * Below is shown an example:
+ *
+ * <pre>
+ *   provisioning.properties:
+ *     customizers:
+ *     - $brooklyn:object:
+ *         type: brooklyn.location.blockstore.openstack.OpenstackNewVolumeCustomizer
+ *         object.fields:
+ *           volumes:
+ *           - blockDevice:
+ *               sizeInGb: 3
+ *               deviceSuffix: 'b'
+ *               deleteOnTermination: false
+ *               tags:
+ *                 brooklyn: br-example-val-test-1
+ *            filesystem:
+ *              mountPoint: /mount/brooklyn/b
+ *              filesystemType: ext3
+ * </pre>
+ *
+ * Important notice is that KVM is configured as the default hypervisor for OpenStack which means that the defined device name will be of type /dev/vd*.
+ * This means that the device suffix must be set as the next letter in alphabetical order from the existing device names on the VM.
+ */
+
 public class OpenstackNewVolumeCustomizer extends BasicJcloudsLocationCustomizer {
 
     private static final OpenstackVolumeManager openstackVolumeManager = new OpenstackVolumeManager();

--- a/blockstore/src/main/java/brooklyn/location/blockstore/openstack/OpenstackNewVolumeCustomizer.java
+++ b/blockstore/src/main/java/brooklyn/location/blockstore/openstack/OpenstackNewVolumeCustomizer.java
@@ -2,17 +2,9 @@ package brooklyn.location.blockstore.openstack;
 
 import brooklyn.location.blockstore.BlockDeviceOptions;
 import brooklyn.location.blockstore.FilesystemOptions;
-import brooklyn.location.blockstore.api.MountedBlockDevice;
+import brooklyn.location.blockstore.NewVolumeCustomizer;
 import brooklyn.location.blockstore.api.VolumeManager;
-import com.google.common.base.Optional;
-import com.google.common.collect.Maps;
-import org.apache.brooklyn.location.jclouds.BasicJcloudsLocationCustomizer;
-import org.apache.brooklyn.location.jclouds.JcloudsLocation;
-import org.apache.brooklyn.location.jclouds.JcloudsMachineLocation;
-import org.jclouds.compute.ComputeService;
-import org.jclouds.compute.domain.NodeMetadata;
 
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -25,14 +17,14 @@ import java.util.Map;
  *     customizers:
  *     - $brooklyn:object:
  *         type: brooklyn.location.blockstore.openstack.OpenstackNewVolumeCustomizer
- *         object.fields:
+ *         brooklyn.config:
  *           volumes:
  *           - blockDevice:
  *               sizeInGb: 3
  *               deviceSuffix: 'b'
- *               deleteOnTermination: false
+ *               deleteOnTermination: true
  *               tags:
- *                 brooklyn: br-example-val-test-1
+ *                 brooklyn: br-example-test-1
  *            filesystem:
  *              mountPoint: /mount/brooklyn/b
  *              filesystemType: ext3
@@ -42,78 +34,17 @@ import java.util.Map;
  * This means that the device suffix must be set as the next letter in alphabetical order from the existing device names on the VM.
  */
 
-public class OpenstackNewVolumeCustomizer extends BasicJcloudsLocationCustomizer {
-
-    private static final OpenstackVolumeManager openstackVolumeManager = new OpenstackVolumeManager();
-
-    private Map<BlockDeviceOptions, FilesystemOptions> volumes;
-
-    protected MountedBlockDevice mountedBlockDevice;
-
-    public OpenstackNewVolumeCustomizer(Map<BlockDeviceOptions, FilesystemOptions> volumes) {
-        this.volumes = volumes;
-        this.mountedBlockDevice = null;
-    }
+public class OpenstackNewVolumeCustomizer extends NewVolumeCustomizer {
 
     public OpenstackNewVolumeCustomizer() {
         // for reflective creation (e.g. with $brooklyn:object)
     }
 
+    public OpenstackNewVolumeCustomizer(Map<BlockDeviceOptions, FilesystemOptions> volume) {
+        super(volume);
+    }
+
     protected VolumeManager getVolumeManager() {
         return new OpenstackVolumeManager();
-    }
-
-    public MountedBlockDevice getMountedBlockDevice() {
-        return mountedBlockDevice;
-    }
-
-    @SuppressWarnings("unchecked")
-    public void setVolumes(List<Map<String, ?>> val) {
-        volumes = Maps.newLinkedHashMap();
-        if (val == null) {
-            return;
-        }
-        for (Map<String,?> volume : val) {
-            BlockDeviceOptions bdOptions;
-            FilesystemOptions fsOptions;
-            Object blockDevice = volume.get("blockDevice");
-            if (blockDevice instanceof Map<?,?>) {
-                bdOptions = BlockDeviceOptions.fromMap((Map<String, ?>) blockDevice);
-            } else if (blockDevice instanceof BlockDeviceOptions) {
-                bdOptions = (BlockDeviceOptions) blockDevice;
-            } else {
-                throw new IllegalArgumentException("Invalid blockDevice "+blockDevice+ (blockDevice == null ? "" : " of type "+blockDevice.getClass().getName()));
-            }
-
-            Object filesystem = volume.get("filesystem");
-            if (filesystem instanceof Map<?,?>) {
-                fsOptions = FilesystemOptions.fromMap((Map<String, ?>) filesystem);
-            } else if (filesystem instanceof FilesystemOptions) {
-                fsOptions = (FilesystemOptions) filesystem;
-            } else {
-                throw new IllegalArgumentException("Invalid filesystem "+filesystem+ (filesystem == null ? "" : " of type "+filesystem.getClass().getName()));
-            }
-
-            volumes.put(bdOptions, fsOptions);
-        }
-    }
-
-    public void customize(JcloudsLocation location, ComputeService computeService, JcloudsMachineLocation machine) {
-        createAndAttachDisks(machine);
-    }
-
-    protected void createAndAttachDisks(JcloudsMachineLocation machine) {
-        for (Map.Entry<BlockDeviceOptions, FilesystemOptions> entry : volumes.entrySet()) {
-            BlockDeviceOptions blockOptions = entry.getKey();
-            FilesystemOptions filesystemOptions = entry.getValue();
-            if (filesystemOptions != null) {
-                BlockDeviceOptions blockOptionsCopy = BlockDeviceOptions.copy(blockOptions);
-                Optional<NodeMetadata> node = machine.getOptionalNode();
-                if (node.isPresent()) {
-                    blockOptionsCopy.zone(node.get().getLocation().getId());
-                }
-                mountedBlockDevice = openstackVolumeManager.createAttachAndMountVolume(machine, blockOptionsCopy, filesystemOptions);
-            }
-        }
     }
 }

--- a/blockstore/src/main/java/brooklyn/location/blockstore/openstack/OpenstackNewVolumeCustomizer.java
+++ b/blockstore/src/main/java/brooklyn/location/blockstore/openstack/OpenstackNewVolumeCustomizer.java
@@ -1,7 +1,5 @@
 package brooklyn.location.blockstore.openstack;
 
-import brooklyn.location.blockstore.BlockDeviceOptions;
-import brooklyn.location.blockstore.FilesystemOptions;
 import brooklyn.location.blockstore.NewVolumeCustomizer;
 import brooklyn.location.blockstore.api.VolumeManager;
 
@@ -40,7 +38,7 @@ public class OpenstackNewVolumeCustomizer extends NewVolumeCustomizer {
         // for reflective creation (e.g. with $brooklyn:object)
     }
 
-    public OpenstackNewVolumeCustomizer(Map<BlockDeviceOptions, FilesystemOptions> volume) {
+    public OpenstackNewVolumeCustomizer(Map<?, ?> volume) {
         super(volume);
     }
 

--- a/blockstore/src/test/java/brooklyn/location/blockstore/AbstractVolumeManagerLiveTest.java
+++ b/blockstore/src/test/java/brooklyn/location/blockstore/AbstractVolumeManagerLiveTest.java
@@ -13,7 +13,7 @@ import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.internal.BrooklynProperties;
-import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
+import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
 import org.apache.brooklyn.location.jclouds.JcloudsLocation;
 import org.apache.brooklyn.location.jclouds.JcloudsSshMachineLocation;
 import org.apache.brooklyn.location.ssh.SshMachineLocation;
@@ -48,7 +48,9 @@ public abstract class AbstractVolumeManagerLiveTest {
     protected VolumeManager volumeManager;
     protected BlockDevice volume;
     protected List<JcloudsSshMachineLocation> machines = Lists.newCopyOnWriteArrayList();
-    
+
+    // TODO Consider removing
+    @Deprecated
     protected abstract String getProvider();
     protected abstract JcloudsLocation createJcloudsLocation();
     protected abstract int getVolumeSize();
@@ -65,10 +67,10 @@ public abstract class AbstractVolumeManagerLiveTest {
 
     @BeforeMethod(alwaysRun=true)
     public void setUp() throws Exception {
-        ctx = new LocalManagementContext();
-        brooklynProperties = (BrooklynProperties) ctx.getConfig();
+        brooklynProperties = BrooklynProperties.Factory.newDefault();
         stripBrooklynProperties(brooklynProperties);
         addBrooklynProperties(brooklynProperties);
+        ctx = new LocalManagementContextForTests(brooklynProperties);
 
         jcloudsLocation = createJcloudsLocation();
         volumeManager = createVolumeManager(jcloudsLocation);
@@ -94,7 +96,8 @@ public abstract class AbstractVolumeManagerLiveTest {
     protected static void stripBrooklynProperties(BrooklynProperties props) {
         for (String key : ImmutableSet.copyOf(props.asMapWithStringKeys().keySet())) {
             if (!key.startsWith(BROOKLYN_PROPERTIES_JCLOUDS_PREFIX + "openstack-cinder")
-                    && !(key.startsWith(BROOKLYN_PROPERTIES_JCLOUDS_PREFIX + "openstack-nova"))) {
+                    && !key.startsWith(BROOKLYN_PROPERTIES_JCLOUDS_PREFIX + "openstack-nova")
+                    && !key.startsWith(BROOKLYN_PROPERTIES_JCLOUDS_PREFIX + "aws-ec2")) {
                     props.remove(key);
             }
             if (key.startsWith(BROOKLYN_PROPERTIES_JCLOUDS_LEGACY_PREFIX) && !(key.endsWith("identity") || key.endsWith("credential"))) {

--- a/blockstore/src/test/java/brooklyn/location/blockstore/AbstractVolumeManagerLiveTest.java
+++ b/blockstore/src/test/java/brooklyn/location/blockstore/AbstractVolumeManagerLiveTest.java
@@ -53,6 +53,7 @@ public abstract class AbstractVolumeManagerLiveTest {
     protected abstract JcloudsLocation createJcloudsLocation();
     protected abstract int getVolumeSize();
     protected abstract String getDefaultAvailabilityZone();
+    protected abstract char getDefaultDeviseSuffix();
     protected abstract void assertVolumeAvailable(BlockDevice blockDevice);
     protected abstract JcloudsSshMachineLocation createJcloudsMachine() throws Exception;
 
@@ -94,7 +95,8 @@ public abstract class AbstractVolumeManagerLiveTest {
         for (String key : ImmutableSet.copyOf(props.asMapWithStringKeys().keySet())) {
             if (key.startsWith(BROOKLYN_PROPERTIES_JCLOUDS_PREFIX) && !(key.endsWith("identity") || key.endsWith("credential") || key.endsWith("loginUser.privateKeyFile"))) {
                 if (!(key.startsWith(BROOKLYN_PROPERTIES_JCLOUDS_PREFIX + "openstack-nova") &&
-                        (key.endsWith("auto-create-floating-ips") || key.endsWith("auto-generate-keypairs") || key.endsWith("keyPair")|| key.endsWith("keystone.credential-type")))) {
+                        (key.endsWith("auto-create-floating-ips") || key.endsWith("auto-generate-keypairs") || key.endsWith("keyPair")
+                                || key.endsWith("keystone.credential-type") || key.endsWith("endpoint")))) {
                     props.remove(key);
                 }
             }
@@ -124,6 +126,7 @@ public abstract class AbstractVolumeManagerLiveTest {
                 "purpose", "brooklyn-blockstore-VolumeManagerLiveTest");
         BlockDeviceOptions options = new BlockDeviceOptions()
                 .zone(getDefaultAvailabilityZone())
+                .deviceSuffix(getDefaultDeviseSuffix())
                 .sizeInGb(getVolumeSize())
                 .tags(tags);
         volume = volumeManager.createBlockDevice(jcloudsLocation, options);
@@ -131,7 +134,7 @@ public abstract class AbstractVolumeManagerLiveTest {
     }
 
     // Does the attach+mount twice to ensure that cleanup worked
-    @Test(groups="Live"/*, dependsOnMethods = "testCreateVolume"*/)
+    @Test(groups="Live", dependsOnMethods = "testCreateVolume")
     public void testCreateAndAttachVolume() throws Exception {
 
         String mountPoint = "/var/opt2/test1";
@@ -139,7 +142,7 @@ public abstract class AbstractVolumeManagerLiveTest {
         final BlockDeviceOptions blockDeviceOptions = new BlockDeviceOptions()
                 .sizeInGb(getVolumeSize())
                 .zone(getDefaultAvailabilityZone())
-                .deviceSuffix('h')
+                .deviceSuffix(getDefaultDeviseSuffix())
                 .tags(ImmutableMap.of(
                         "user", System.getProperty("user.name"),
                         "purpose", "brooklyn-blockstore-VolumeManagerLiveTest"));
@@ -206,7 +209,7 @@ public abstract class AbstractVolumeManagerLiveTest {
         BlockDeviceOptions deviceOptions = new BlockDeviceOptions()
                 .sizeInGb(getVolumeSize())
                 .zone(getDefaultAvailabilityZone())
-                .deviceSuffix('h')
+                .deviceSuffix(getDefaultDeviseSuffix())
                 .tags(ImmutableMap.of(
                     "user", user,
                     "purpose", "brooklyn-blockstore-test-move-between-machines"));

--- a/blockstore/src/test/java/brooklyn/location/blockstore/AbstractVolumeManagerLiveTest.java
+++ b/blockstore/src/test/java/brooklyn/location/blockstore/AbstractVolumeManagerLiveTest.java
@@ -58,7 +58,6 @@ public abstract class AbstractVolumeManagerLiveTest {
 
     /**
      * Speed tests up by rebinding and returning an existing virtual machine.
-     * See {@link JcloudsLocation#rebindMachine(brooklyn.util.config.ConfigBag)}.
      */
     protected abstract Optional<JcloudsSshMachineLocation> rebindJcloudsMachine();
     
@@ -93,8 +92,11 @@ public abstract class AbstractVolumeManagerLiveTest {
 
     protected static void stripBrooklynProperties(BrooklynProperties props) {
         for (String key : ImmutableSet.copyOf(props.asMapWithStringKeys().keySet())) {
-            if (key.startsWith(BROOKLYN_PROPERTIES_JCLOUDS_PREFIX) && !(key.endsWith("identity") || key.endsWith("credential"))) {
-                props.remove(key);
+            if (key.startsWith(BROOKLYN_PROPERTIES_JCLOUDS_PREFIX) && !(key.endsWith("identity") || key.endsWith("credential") || key.endsWith("loginUser.privateKeyFile"))) {
+                if (!(key.startsWith(BROOKLYN_PROPERTIES_JCLOUDS_PREFIX + "openstack-nova") &&
+                        (key.endsWith("auto-create-floating-ips") || key.endsWith("auto-generate-keypairs") || key.endsWith("keyPair")|| key.endsWith("keystone.credential-type")))) {
+                    props.remove(key);
+                }
             }
             if (key.startsWith(BROOKLYN_PROPERTIES_JCLOUDS_LEGACY_PREFIX) && !(key.endsWith("identity") || key.endsWith("credential"))) {
                 props.remove(key);
@@ -129,7 +131,7 @@ public abstract class AbstractVolumeManagerLiveTest {
     }
 
     // Does the attach+mount twice to ensure that cleanup worked
-    @Test(groups="Live", dependsOnMethods = {"testCreateVolume"})
+    @Test(groups="Live"/*, dependsOnMethods = "testCreateVolume"*/)
     public void testCreateAndAttachVolume() throws Exception {
 
         String mountPoint = "/var/opt2/test1";

--- a/blockstore/src/test/java/brooklyn/location/blockstore/AbstractVolumeManagerLiveTest.java
+++ b/blockstore/src/test/java/brooklyn/location/blockstore/AbstractVolumeManagerLiveTest.java
@@ -1,14 +1,14 @@
 package brooklyn.location.blockstore;
 
-import static org.apache.brooklyn.util.ssh.BashCommands.sudo;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotEquals;
-
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.util.List;
-import java.util.Map;
-
+import brooklyn.location.blockstore.api.BlockDevice;
+import brooklyn.location.blockstore.api.MountedBlockDevice;
+import brooklyn.location.blockstore.api.VolumeManager;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.io.Files;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.core.entity.Entities;
@@ -23,16 +23,16 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
-import com.google.common.io.Files;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.util.List;
+import java.util.Map;
 
-import brooklyn.location.blockstore.api.BlockDevice;
-import brooklyn.location.blockstore.api.MountedBlockDevice;
-import brooklyn.location.blockstore.api.VolumeManager;;
+import static org.apache.brooklyn.util.ssh.BashCommands.sudo;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+
+;
 
 public abstract class AbstractVolumeManagerLiveTest {
 
@@ -53,7 +53,7 @@ public abstract class AbstractVolumeManagerLiveTest {
     protected abstract JcloudsLocation createJcloudsLocation();
     protected abstract int getVolumeSize();
     protected abstract String getDefaultAvailabilityZone();
-    protected abstract char getDefaultDeviseSuffix();
+    protected abstract char getDefaultDeviceSuffix();
     protected abstract void assertVolumeAvailable(BlockDevice blockDevice);
     protected abstract JcloudsSshMachineLocation createJcloudsMachine() throws Exception;
 
@@ -93,12 +93,9 @@ public abstract class AbstractVolumeManagerLiveTest {
 
     protected static void stripBrooklynProperties(BrooklynProperties props) {
         for (String key : ImmutableSet.copyOf(props.asMapWithStringKeys().keySet())) {
-            if (key.startsWith(BROOKLYN_PROPERTIES_JCLOUDS_PREFIX) && !(key.endsWith("identity") || key.endsWith("credential") || key.endsWith("loginUser.privateKeyFile"))) {
-                if (!(key.startsWith(BROOKLYN_PROPERTIES_JCLOUDS_PREFIX + "openstack-nova") &&
-                        (key.endsWith("auto-create-floating-ips") || key.endsWith("auto-generate-keypairs") || key.endsWith("keyPair")
-                                || key.endsWith("keystone.credential-type") || key.endsWith("endpoint")))) {
+            if (!key.startsWith(BROOKLYN_PROPERTIES_JCLOUDS_PREFIX + "openstack-cinder")
+                    && !(key.startsWith(BROOKLYN_PROPERTIES_JCLOUDS_PREFIX + "openstack-nova"))) {
                     props.remove(key);
-                }
             }
             if (key.startsWith(BROOKLYN_PROPERTIES_JCLOUDS_LEGACY_PREFIX) && !(key.endsWith("identity") || key.endsWith("credential"))) {
                 props.remove(key);
@@ -126,7 +123,7 @@ public abstract class AbstractVolumeManagerLiveTest {
                 "purpose", "brooklyn-blockstore-VolumeManagerLiveTest");
         BlockDeviceOptions options = new BlockDeviceOptions()
                 .zone(getDefaultAvailabilityZone())
-                .deviceSuffix(getDefaultDeviseSuffix())
+                .deviceSuffix(getDefaultDeviceSuffix())
                 .sizeInGb(getVolumeSize())
                 .tags(tags);
         volume = volumeManager.createBlockDevice(jcloudsLocation, options);
@@ -142,7 +139,7 @@ public abstract class AbstractVolumeManagerLiveTest {
         final BlockDeviceOptions blockDeviceOptions = new BlockDeviceOptions()
                 .sizeInGb(getVolumeSize())
                 .zone(getDefaultAvailabilityZone())
-                .deviceSuffix(getDefaultDeviseSuffix())
+                .deviceSuffix(getDefaultDeviceSuffix())
                 .tags(ImmutableMap.of(
                         "user", System.getProperty("user.name"),
                         "purpose", "brooklyn-blockstore-VolumeManagerLiveTest"));
@@ -209,7 +206,7 @@ public abstract class AbstractVolumeManagerLiveTest {
         BlockDeviceOptions deviceOptions = new BlockDeviceOptions()
                 .sizeInGb(getVolumeSize())
                 .zone(getDefaultAvailabilityZone())
-                .deviceSuffix(getDefaultDeviseSuffix())
+                .deviceSuffix(getDefaultDeviceSuffix())
                 .tags(ImmutableMap.of(
                     "user", user,
                     "purpose", "brooklyn-blockstore-test-move-between-machines"));

--- a/blockstore/src/test/java/brooklyn/location/blockstore/VolumeManagersTest.java
+++ b/blockstore/src/test/java/brooklyn/location/blockstore/VolumeManagersTest.java
@@ -60,7 +60,7 @@ public class VolumeManagersTest {
 
     @Test
     public void testOpenstackVolumeManager() {
-        JcloudsLocation openstackLocation = locationFor(OpenStackVolumeManagerLiveTest.LOCATION_SPEC);
+        JcloudsLocation openstackLocation = locationFor(OpenStackVolumeManagerLiveTest.locationConfig.LOCATION_SPEC);
         assertTrue(VolumeManagers.isVolumeManagerSupportedForLocation(openstackLocation));
         assertEquals(VolumeManagers.newVolumeManager(openstackLocation).getClass(), OpenstackVolumeManager.class);
     }

--- a/blockstore/src/test/java/brooklyn/location/blockstore/ec2/Ec2NewVolumeCustomizerLiveTest.java
+++ b/blockstore/src/test/java/brooklyn/location/blockstore/ec2/Ec2NewVolumeCustomizerLiveTest.java
@@ -39,6 +39,16 @@ public class Ec2NewVolumeCustomizerLiveTest extends BrooklynAppLiveTestSupport {
                         "filesystem", MutableMap.of(
                                 "mountPoint", "/mount/brooklyn/h",
                                 "filesystemType", "ext3"
+                        )),
+
+                MutableMap.of("blockDevice", MutableMap.of(
+                        "sizeInGb", 3,
+                        "deviceSuffix", 'g',
+                        "deleteOnTermination", true
+                        ),
+                        "filesystem", MutableMap.of(
+                                "mountPoint", "/mount/brooklyn/g",
+                                "filesystemType", "ext3"
                         ))));
 
         EmptySoftwareProcess entity = app.createAndManageChild(EntitySpec.create(EmptySoftwareProcess.class)

--- a/blockstore/src/test/java/brooklyn/location/blockstore/ec2/Ec2NewVolumeCustomizerLiveTest.java
+++ b/blockstore/src/test/java/brooklyn/location/blockstore/ec2/Ec2NewVolumeCustomizerLiveTest.java
@@ -1,0 +1,56 @@
+package brooklyn.location.blockstore.ec2;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.core.test.BrooklynAppLiveTestSupport;
+import org.apache.brooklyn.entity.machine.MachineEntity;
+import org.apache.brooklyn.entity.software.base.EmptySoftwareProcess;
+import org.apache.brooklyn.entity.software.base.lifecycle.NaiveScriptRunner;
+import org.apache.brooklyn.entity.software.base.lifecycle.ScriptHelper;
+import org.apache.brooklyn.location.jclouds.JcloudsLocationConfig;
+import org.apache.brooklyn.util.collections.MutableList;
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static org.testng.Assert.assertTrue;
+
+public class Ec2NewVolumeCustomizerLiveTest extends BrooklynAppLiveTestSupport {
+
+    protected Location jcloudsLocation;
+
+    @Test(groups = "Live")
+    public void testCustomizerCreatesAndAttachesNewVolumeOnProvisioningTime() {
+        jcloudsLocation = mgmt.getLocationRegistry().getLocationManaged("jclouds:aws-ec2:eu-west-1", ImmutableMap.<String, Object>builder()
+                .put("osFamily", "centos")
+                .put("imageId", "eu-west-1/ami-1d841c6a")
+                .build());
+
+        Ec2NewVolumeCustomizer customizer = new Ec2NewVolumeCustomizer();
+        customizer.setVolumes(MutableList.<Map<?, ?>>of(
+                MutableMap.of("blockDevice", MutableMap.of(
+                        "sizeInGb", 3,
+                        "deviceSuffix", 'h',
+                        "deleteOnTermination", true
+                        ),
+                        "filesystem", MutableMap.of(
+                                "mountPoint", "/mount/brooklyn/h",
+                                "filesystemType", "ext3"
+                        ))));
+
+        EmptySoftwareProcess entity = app.createAndManageChild(EntitySpec.create(EmptySoftwareProcess.class)
+                .configure(MachineEntity.PROVISIONING_PROPERTIES.subKey(JcloudsLocationConfig.JCLOUDS_LOCATION_CUSTOMIZERS.getName()),
+                        MutableList.of(customizer)));
+
+        app.start(ImmutableList.of(jcloudsLocation));
+
+        ScriptHelper scriptHelper = new ScriptHelper((NaiveScriptRunner) entity.getDriver(),
+                "Checking machine disks").body.append("df").gatherOutput();
+
+        scriptHelper.execute();
+        assertTrue(scriptHelper.getResultStdout().contains("/mount/brooklyn/h"));
+    }
+}

--- a/blockstore/src/test/java/brooklyn/location/blockstore/ec2/Ec2NewVolumeCustomizerLiveTest.java
+++ b/blockstore/src/test/java/brooklyn/location/blockstore/ec2/Ec2NewVolumeCustomizerLiveTest.java
@@ -1,5 +1,6 @@
 package brooklyn.location.blockstore.ec2;
 
+import brooklyn.location.blockstore.api.VolumeOptions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.brooklyn.api.entity.EntitySpec;
@@ -30,26 +31,28 @@ public class Ec2NewVolumeCustomizerLiveTest extends BrooklynAppLiveTestSupport {
                 .build());
 
         Ec2NewVolumeCustomizer customizer = new Ec2NewVolumeCustomizer();
-        customizer.setVolumes(MutableList.<Map<?, ?>>of(
-                MutableMap.of("blockDevice", MutableMap.of(
-                        "sizeInGb", 3,
-                        "deviceSuffix", 'h',
-                        "deleteOnTermination", true
-                        ),
+        customizer.setVolumes(MutableList.of(
+                VolumeOptions.fromMap(MutableMap.<String, Map<String,?>>of(
+                        "blockDevice", MutableMap.of(
+                            "sizeInGb", 3,
+                            "deviceSuffix", 'h',
+                            "deleteOnTermination", true
+                            ),
                         "filesystem", MutableMap.of(
                                 "mountPoint", "/mount/brooklyn/h",
                                 "filesystemType", "ext3"
-                        )),
+                        ))),
 
-                MutableMap.of("blockDevice", MutableMap.of(
-                        "sizeInGb", 3,
-                        "deviceSuffix", 'g',
-                        "deleteOnTermination", true
+                VolumeOptions.fromMap(MutableMap.<String, Map<String,?>>of(
+                        "blockDevice", MutableMap.of(
+                            "sizeInGb", 3,
+                            "deviceSuffix", 'g',
+                            "deleteOnTermination", true
                         ),
                         "filesystem", MutableMap.of(
                                 "mountPoint", "/mount/brooklyn/g",
                                 "filesystemType", "ext3"
-                        ))));
+                        )))));
 
         EmptySoftwareProcess entity = app.createAndManageChild(EntitySpec.create(EmptySoftwareProcess.class)
                 .configure(MachineEntity.PROVISIONING_PROPERTIES.subKey(JcloudsLocationConfig.JCLOUDS_LOCATION_CUSTOMIZERS.getName()),

--- a/blockstore/src/test/java/brooklyn/location/blockstore/ec2/Ec2VolumeCustomizerLiveTest.java
+++ b/blockstore/src/test/java/brooklyn/location/blockstore/ec2/Ec2VolumeCustomizerLiveTest.java
@@ -8,13 +8,14 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.List;
 import java.util.Map;
 
+import brooklyn.location.blockstore.api.VolumeOptions;
 import org.apache.brooklyn.location.jclouds.JcloudsLocation;
 import org.apache.brooklyn.location.jclouds.JcloudsLocationCustomizer;
+import org.apache.brooklyn.util.collections.MutableList;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 
 import brooklyn.location.blockstore.AbstractVolumeCustomizerLiveTest;
 import brooklyn.location.blockstore.BlockDeviceOptions;
@@ -91,7 +92,7 @@ public class Ec2VolumeCustomizerLiveTest extends AbstractVolumeCustomizerLiveTes
         List<Integer> capacities = ImmutableList.of(1);
         List<String> mountPoints = ImmutableList.of("/mnt/brooklyn/g");
 
-        Map<BlockDeviceOptions, FilesystemOptions> volumes = Maps.newLinkedHashMap();
+        List<VolumeOptions> volumes = MutableList.of();
         for (int i = 0; i < capacities.size(); i++) {
             Integer capacity = checkNotNull(capacities.get(i), "capacity(%s)", i);
             Character deviceSuffix = checkNotNull(deviceSuffixes.get(i), "deviceSuffix(%s)", i);
@@ -103,7 +104,7 @@ public class Ec2VolumeCustomizerLiveTest extends AbstractVolumeCustomizerLiveTes
                             "user", System.getProperty("user.name"),
                             "purpose", "brooklyn-blockstore-VolumeCustomizerLiveTest"));
             FilesystemOptions filesystemOptions = new FilesystemOptions(mountPoints.get(i), "ext3");
-            volumes.put(blockDeviceOptions, filesystemOptions);
+            volumes.add(new VolumeOptions(blockDeviceOptions, filesystemOptions));
         }
         
         JcloudsLocationCustomizer customizer = new Ec2NewVolumeCustomizer(volumes);

--- a/blockstore/src/test/java/brooklyn/location/blockstore/ec2/Ec2VolumeCustomizerLiveTest.java
+++ b/blockstore/src/test/java/brooklyn/location/blockstore/ec2/Ec2VolumeCustomizerLiveTest.java
@@ -21,7 +21,7 @@ import brooklyn.location.blockstore.AbstractVolumeCustomizerLiveTest;
 import brooklyn.location.blockstore.BlockDeviceOptions;
 import brooklyn.location.blockstore.FilesystemOptions;
 
-@Test
+@Test(groups = "WIP")
 public class Ec2VolumeCustomizerLiveTest extends AbstractVolumeCustomizerLiveTest {
 
     @Override

--- a/blockstore/src/test/java/brooklyn/location/blockstore/ec2/Ec2VolumeManagerLiveTest.java
+++ b/blockstore/src/test/java/brooklyn/location/blockstore/ec2/Ec2VolumeManagerLiveTest.java
@@ -38,6 +38,11 @@ public class Ec2VolumeManagerLiveTest extends AbstractVolumeManagerLiveTest {
     }
 
     @Override
+    protected char getDefaultDeviseSuffix() {
+        return 'h';
+    }
+
+    @Override
     protected JcloudsLocation createJcloudsLocation() {
         return (JcloudsLocation) ctx.getLocationRegistry().getLocationManaged(LOCATION_SPEC);
     }

--- a/blockstore/src/test/java/brooklyn/location/blockstore/ec2/Ec2VolumeManagerLiveTest.java
+++ b/blockstore/src/test/java/brooklyn/location/blockstore/ec2/Ec2VolumeManagerLiveTest.java
@@ -1,21 +1,18 @@
 package brooklyn.location.blockstore.ec2;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
-
+import brooklyn.location.blockstore.AbstractVolumeManagerLiveTest;
+import brooklyn.location.blockstore.api.BlockDevice;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
 import org.apache.brooklyn.location.jclouds.JcloudsLocation;
-import org.apache.brooklyn.location.jclouds.JcloudsLocationConfig;
 import org.apache.brooklyn.location.jclouds.JcloudsSshMachineLocation;
 import org.jclouds.ec2.domain.Volume;
 import org.testng.annotations.Test;
 
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableMap;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 
-import brooklyn.location.blockstore.AbstractVolumeManagerLiveTest;
-import brooklyn.location.blockstore.api.BlockDevice;
-
-@Test
+@Test(groups = "WIP")
 public class Ec2VolumeManagerLiveTest extends AbstractVolumeManagerLiveTest {
 
     // Note we're using the region-name with an explicit availability zone, as is done in the 

--- a/blockstore/src/test/java/brooklyn/location/blockstore/ec2/Ec2VolumeManagerLiveTest.java
+++ b/blockstore/src/test/java/brooklyn/location/blockstore/ec2/Ec2VolumeManagerLiveTest.java
@@ -22,7 +22,7 @@ public class Ec2VolumeManagerLiveTest extends AbstractVolumeManagerLiveTest {
     // availability zone.
     
     public static final String PROVIDER = "aws-ec2";
-    public static final String REGION_NAME = "us-east-1c";
+    public static final String REGION_NAME = "eu-west-1";
     public static final String AVAILABILITY_ZONE_NAME = REGION_NAME;
     public static final String LOCATION_SPEC = PROVIDER + (REGION_NAME == null ? "" : ":" + REGION_NAME);
     public static final String TINY_HARDWARE_ID = "t1.micro";
@@ -30,7 +30,7 @@ public class Ec2VolumeManagerLiveTest extends AbstractVolumeManagerLiveTest {
 
     // Must be an image that supports EBS
     // {id=us-east-1/ami-4e32c626, providerId=ami-4e32c626, name=RightImage_CentOS_6.5_x64_v14.0_EBS, location={scope=REGION, id=us-east-1, description=us-east-1, parent=aws-ec2, iso3166Codes=[US-VA]}, os={family=centos, arch=paravirtual, version=5.0, description=411009282317/RightImage_CentOS_6.5_x64_v14.0_EBS, is64Bit=true}, description=RightImage_CentOS_6.5_x64_v14.0_EBS, version=14.0_EBS, status=AVAILABLE[available], loginUser=root, userMetadata={owner=411009282317, rootDeviceType=ebs, virtualizationType=paravirtual, hypervisor=xen}}
-    public static final String CENTOS_IMAGE_ID = "us-east-1/ami-4e32c626";
+    public static final String CENTOS_IMAGE_ID = "eu-west-1/ami-1d841c6a";
     
     @Override
     protected String getProvider() {
@@ -38,7 +38,7 @@ public class Ec2VolumeManagerLiveTest extends AbstractVolumeManagerLiveTest {
     }
 
     @Override
-    protected char getDefaultDeviseSuffix() {
+    protected char getDefaultDeviceSuffix() {
         return 'h';
     }
 

--- a/blockstore/src/test/java/brooklyn/location/blockstore/ec2/Ec2VolumeManagerLiveTest.java
+++ b/blockstore/src/test/java/brooklyn/location/blockstore/ec2/Ec2VolumeManagerLiveTest.java
@@ -4,6 +4,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
 import org.apache.brooklyn.location.jclouds.JcloudsLocation;
+import org.apache.brooklyn.location.jclouds.JcloudsLocationConfig;
 import org.apache.brooklyn.location.jclouds.JcloudsSshMachineLocation;
 import org.jclouds.ec2.domain.Volume;
 import org.testng.annotations.Test;
@@ -24,7 +25,7 @@ public class Ec2VolumeManagerLiveTest extends AbstractVolumeManagerLiveTest {
     public static final String PROVIDER = "aws-ec2";
     public static final String REGION_NAME = "eu-west-1";
     public static final String AVAILABILITY_ZONE_NAME = REGION_NAME;
-    public static final String LOCATION_SPEC = PROVIDER + (REGION_NAME == null ? "" : ":" + REGION_NAME);
+    public static final String LOCATION_SPEC = "jclouds:" + PROVIDER + (REGION_NAME == null ? "" : ":" + REGION_NAME);
     public static final String TINY_HARDWARE_ID = "t1.micro";
     public static final String SMALL_HARDWARE_ID = "m1.small";
 

--- a/blockstore/src/test/java/brooklyn/location/blockstore/ec2/YamlTest.java
+++ b/blockstore/src/test/java/brooklyn/location/blockstore/ec2/YamlTest.java
@@ -48,12 +48,10 @@ public class YamlTest extends AbstractYamlTest {
 
         JcloudsLocation loc = (JcloudsLocation) Iterables.getOnlyElement(app.getLocations());
         Ec2NewVolumeCustomizer customizer = (Ec2NewVolumeCustomizer) Iterables.getOnlyElement(loc.config().get(JcloudsLocation.JCLOUDS_LOCATION_CUSTOMIZERS));
+;
+        Map<BlockDeviceOptions, FilesystemOptions> volumes = customizer.getVolumes().isEmpty() ?
+                MutableMap.<BlockDeviceOptions, FilesystemOptions>of() : customizer.getParsedVolumes().iterator().next();
 
-        Map<BlockDeviceOptions, FilesystemOptions> volumes = MutableMap.of();
-
-        if (customizer.getVolumes().iterator().hasNext()) {
-            volumes =(Map<BlockDeviceOptions, FilesystemOptions>) customizer.getVolumes().iterator().next();
-        }
         String msg = "volumes="+volumes;
         
         assertEquals(volumes.size(), 1, msg);

--- a/blockstore/src/test/java/brooklyn/location/blockstore/ec2/YamlTest.java
+++ b/blockstore/src/test/java/brooklyn/location/blockstore/ec2/YamlTest.java
@@ -8,6 +8,7 @@ import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.camp.brooklyn.AbstractYamlTest;
 import org.apache.brooklyn.entity.stock.BasicApplication;
 import org.apache.brooklyn.location.jclouds.JcloudsLocation;
+import org.apache.brooklyn.util.collections.MutableMap;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Joiner;
@@ -47,8 +48,12 @@ public class YamlTest extends AbstractYamlTest {
 
         JcloudsLocation loc = (JcloudsLocation) Iterables.getOnlyElement(app.getLocations());
         Ec2NewVolumeCustomizer customizer = (Ec2NewVolumeCustomizer) Iterables.getOnlyElement(loc.config().get(JcloudsLocation.JCLOUDS_LOCATION_CUSTOMIZERS));
-        
-        Map<BlockDeviceOptions, FilesystemOptions> volumes = customizer.getParsedVolumes();
+
+        Map<BlockDeviceOptions, FilesystemOptions> volumes = MutableMap.of();
+
+        if (customizer.getVolumes().iterator().hasNext()) {
+            volumes =(Map<BlockDeviceOptions, FilesystemOptions>) customizer.getVolumes().iterator().next();
+        }
         String msg = "volumes="+volumes;
         
         assertEquals(volumes.size(), 1, msg);

--- a/blockstore/src/test/java/brooklyn/location/blockstore/ec2/YamlTest.java
+++ b/blockstore/src/test/java/brooklyn/location/blockstore/ec2/YamlTest.java
@@ -2,13 +2,13 @@ package brooklyn.location.blockstore.ec2;
 
 import static org.testng.Assert.assertEquals;
 
-import java.util.Map;
+import java.util.List;
 
+import brooklyn.location.blockstore.api.VolumeOptions;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.camp.brooklyn.AbstractYamlTest;
 import org.apache.brooklyn.entity.stock.BasicApplication;
 import org.apache.brooklyn.location.jclouds.JcloudsLocation;
-import org.apache.brooklyn.util.collections.MutableMap;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Joiner;
@@ -49,21 +49,18 @@ public class YamlTest extends AbstractYamlTest {
         JcloudsLocation loc = (JcloudsLocation) Iterables.getOnlyElement(app.getLocations());
         Ec2NewVolumeCustomizer customizer = (Ec2NewVolumeCustomizer) Iterables.getOnlyElement(loc.config().get(JcloudsLocation.JCLOUDS_LOCATION_CUSTOMIZERS));
 ;
-        Map<BlockDeviceOptions, FilesystemOptions> volumes = customizer.getVolumes().isEmpty() ?
-                MutableMap.<BlockDeviceOptions, FilesystemOptions>of() : customizer.getParsedVolumes().iterator().next();
+        List<VolumeOptions> volumes = customizer.getVolumes();
 
-        String msg = "volumes="+volumes;
+        VolumeOptions volume = Iterables.getOnlyElement(volumes);
         
-        assertEquals(volumes.size(), 1, msg);
-        
-        BlockDeviceOptions blockDevice = Iterables.getOnlyElement(volumes.keySet());
+        BlockDeviceOptions blockDevice = volume.getBlockDeviceOptions();
         assertEquals(blockDevice.getSizeInGb(), 1);
         assertEquals(blockDevice.deleteOnTermination(), false);
         assertEquals(blockDevice.getZone(), "us-east-1b");
         assertEquals(blockDevice.getDeviceSuffix(), 'z');
         assertEquals(blockDevice.getTags(), ImmutableMap.of("tag1", "val1"));
 
-        FilesystemOptions filesystemOptions = Iterables.getOnlyElement(volumes.values());
+        FilesystemOptions filesystemOptions = volume.getFilesystemOptions();
         assertEquals(filesystemOptions.getMountPoint(), "/my/mount/point");
         assertEquals(filesystemOptions.getFilesystemType(), "ext3");
     }

--- a/blockstore/src/test/java/brooklyn/location/blockstore/effectors/ExtraHddBodyEffectorLiveTest.java
+++ b/blockstore/src/test/java/brooklyn/location/blockstore/effectors/ExtraHddBodyEffectorLiveTest.java
@@ -19,11 +19,13 @@ import org.testng.annotations.Test;
 
 import java.util.concurrent.ExecutionException;
 
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertNotNull;
 
 public class ExtraHddBodyEffectorLiveTest extends BrooklynAppLiveTestSupport {
-
-    private static final Logger LOG = LoggerFactory.getLogger(ExtraHddBodyEffectorLiveTest.class);
 
     protected Location jcloudsLocation;
     protected BrooklynProperties brooklynProperties;

--- a/blockstore/src/test/java/brooklyn/location/blockstore/effectors/ExtraHddBodyEffectorLiveTest.java
+++ b/blockstore/src/test/java/brooklyn/location/blockstore/effectors/ExtraHddBodyEffectorLiveTest.java
@@ -13,8 +13,6 @@ import org.apache.brooklyn.entity.software.base.EmptySoftwareProcess;
 import org.apache.brooklyn.entity.software.base.lifecycle.NaiveScriptRunner;
 import org.apache.brooklyn.entity.software.base.lifecycle.ScriptHelper;
 import org.apache.brooklyn.test.Asserts;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
 
 import java.util.concurrent.ExecutionException;

--- a/blockstore/src/test/java/brooklyn/location/blockstore/effectors/ExtraHddBodyEffectorTest.java
+++ b/blockstore/src/test/java/brooklyn/location/blockstore/effectors/ExtraHddBodyEffectorTest.java
@@ -36,6 +36,7 @@ public class ExtraHddBodyEffectorTest extends AbstractYamlTest {
         assertEffectorIsProperlyAttached(effector);
     }
 
+    // Run with -da (disable assertions) die to bug in jclouds openstack-nova for not properly cloning template options
     @Test
     public void testEffectorFailsForLocationsNotOfJcloudsMachineLocationType() throws Exception {
 

--- a/blockstore/src/test/java/brooklyn/location/blockstore/effectors/ExtraHddBodyEffectorTest.java
+++ b/blockstore/src/test/java/brooklyn/location/blockstore/effectors/ExtraHddBodyEffectorTest.java
@@ -1,9 +1,7 @@
 package brooklyn.location.blockstore.effectors;
 
-import brooklyn.location.blockstore.BlockDeviceOptions;
-import brooklyn.location.blockstore.FilesystemOptions;
-import brooklyn.location.blockstore.NewVolumeCustomizer;
 import brooklyn.location.blockstore.api.MountedBlockDevice;
+import brooklyn.location.blockstore.api.VolumeOptions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import org.apache.brooklyn.api.effector.Effector;
@@ -12,14 +10,12 @@ import org.apache.brooklyn.camp.brooklyn.AbstractYamlTest;
 import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.location.jclouds.JcloudsMachineLocation;
 import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.flags.TypeCoercions;
 import org.testng.annotations.Test;
 
 import java.util.Map;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 
 public class ExtraHddBodyEffectorTest extends AbstractYamlTest {
 
@@ -97,19 +93,16 @@ public class ExtraHddBodyEffectorTest extends AbstractYamlTest {
                 "  }\n" +
                 "}";
 
-        Map<?, ?> parameterMap = TypeCoercions.coerce(parameterInput, Map.class);
+        Map<String, Map<String, ?>> parameterMap = TypeCoercions.coerce(parameterInput, Map.class);
 
-        Map<BlockDeviceOptions, FilesystemOptions> transformed = NewVolumeCustomizer.transformMapToVolume(parameterMap);
-        assertTrue(((MutableMap) transformed).asImmutableCopy().keySet().iterator().next() instanceof BlockDeviceOptions);
-        assertTrue(((MutableMap) transformed).asImmutableCopy().values().iterator().next() instanceof FilesystemOptions);
+        VolumeOptions transformed = VolumeOptions.fromMap(parameterMap);
 
-        assertEquals(((BlockDeviceOptions) ((MutableMap) transformed).asImmutableCopy().keySet().iterator().next()).getSizeInGb(), 4);
-        assertEquals(((BlockDeviceOptions) ((MutableMap) transformed).asImmutableCopy().keySet().iterator().next()).getDeviceSuffix(), 'h');
-        assertEquals(((BlockDeviceOptions) ((MutableMap) transformed).asImmutableCopy().keySet().iterator().next()).getTags().get("brooklyn"), "br-test-1");
+        assertEquals(transformed.getBlockDeviceOptions().getSizeInGb(), 4);
+        assertEquals(transformed.getBlockDeviceOptions().getDeviceSuffix(), 'h');
+        assertEquals(transformed.getBlockDeviceOptions().getTags().get("brooklyn"), "br-test-1");
 
-        assertEquals(((FilesystemOptions) ((MutableMap) transformed).asImmutableCopy().values().iterator().next()).getFilesystemType(), "ext3");
-        assertEquals(((FilesystemOptions) ((MutableMap) transformed).asImmutableCopy().values().iterator().next()).getMountPoint(),
-                "/mount/brooklyn/h");
+        assertEquals(transformed.getFilesystemOptions().getFilesystemType(), "ext3");
+        assertEquals(transformed.getFilesystemOptions().getMountPoint(), "/mount/brooklyn/h");
 
         String parameterInputWithDoubleSizeInGB = "{\n" +
                 "  \"blockDevice\": {\n" +
@@ -128,14 +121,14 @@ public class ExtraHddBodyEffectorTest extends AbstractYamlTest {
 
         parameterMap = TypeCoercions.coerce(parameterInputWithDoubleSizeInGB, Map.class);
 
-        transformed = NewVolumeCustomizer.transformMapToVolume(parameterMap);
+        transformed = VolumeOptions.fromMap(parameterMap);
 
-        assertEquals(((BlockDeviceOptions) ((MutableMap) transformed).asImmutableCopy().keySet().iterator().next()).getSizeInGb(), 4);
+        assertEquals(transformed.getBlockDeviceOptions().getSizeInGb(), 4);
     }
 
     @Test
     public void testBehaviourWithWrongParametersForAWS() {
-        Map<?, ?> parameterMap;
+        Map<String, Map<String, ?>> parameterMap;
 
         String parameterInputWithMissingSizeInGb = "{\n" +
                 "  \"blockDevice\": {\n" +
@@ -153,7 +146,7 @@ public class ExtraHddBodyEffectorTest extends AbstractYamlTest {
 
         try {
             parameterMap = TypeCoercions.coerce(parameterInputWithMissingSizeInGb, Map.class);
-            NewVolumeCustomizer.transformMapToVolume(parameterMap);
+            VolumeOptions.fromMap(parameterMap);
             Asserts.shouldHaveFailedPreviously("\"blockDevice\" should contain value for \"sizeInGb\"");
         } catch (Exception e) {
             Asserts.expectedFailureOfType(e, IllegalArgumentException.class);
@@ -177,7 +170,7 @@ public class ExtraHddBodyEffectorTest extends AbstractYamlTest {
 
         try {
             parameterMap = TypeCoercions.coerce(parameterInputWithNonIntegerSizeInGb, Map.class);
-            NewVolumeCustomizer.transformMapToVolume(parameterMap);
+            VolumeOptions.fromMap(parameterMap);
             Asserts.shouldHaveFailedPreviously("Trying to set block device with not allowed sizeInGb value");
         } catch (Exception e) {
             Asserts.expectedFailureOfType(e, UnsupportedOperationException.class);
@@ -201,7 +194,7 @@ public class ExtraHddBodyEffectorTest extends AbstractYamlTest {
 
         try {
             parameterMap = TypeCoercions.coerce(parameterInputWithWrongValueTypes, Map.class);
-            NewVolumeCustomizer.transformMapToVolume(parameterMap);
+            VolumeOptions.fromMap(parameterMap);
             Asserts.shouldHaveFailedPreviously();
         } catch (Exception e) {
             Asserts.expectedFailureOfType(e, ClassCastException.class);

--- a/blockstore/src/test/java/brooklyn/location/blockstore/effectors/ExtraHddBodyEffectorTest.java
+++ b/blockstore/src/test/java/brooklyn/location/blockstore/effectors/ExtraHddBodyEffectorTest.java
@@ -2,11 +2,11 @@ package brooklyn.location.blockstore.effectors;
 
 import brooklyn.location.blockstore.BlockDeviceOptions;
 import brooklyn.location.blockstore.FilesystemOptions;
+import brooklyn.location.blockstore.NewVolumeCustomizer;
 import brooklyn.location.blockstore.api.MountedBlockDevice;
-import brooklyn.location.blockstore.effectors.ExtraHddBodyEffector;
-import org.apache.brooklyn.api.effector.Effector;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
+import org.apache.brooklyn.api.effector.Effector;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.camp.brooklyn.AbstractYamlTest;
 import org.apache.brooklyn.core.test.entity.TestEntity;
@@ -99,7 +99,7 @@ public class ExtraHddBodyEffectorTest extends AbstractYamlTest {
 
         Map<?, ?> parameterMap = TypeCoercions.coerce(parameterInput, Map.class);
 
-        Map<BlockDeviceOptions, FilesystemOptions> transformed = ExtraHddBodyEffector.Body.transformMapToLocationCustomizerFields(parameterMap);
+        Map<BlockDeviceOptions, FilesystemOptions> transformed = NewVolumeCustomizer.transformMapToVolume(parameterMap);
         assertTrue(((MutableMap) transformed).asImmutableCopy().keySet().iterator().next() instanceof BlockDeviceOptions);
         assertTrue(((MutableMap) transformed).asImmutableCopy().values().iterator().next() instanceof FilesystemOptions);
 
@@ -128,7 +128,7 @@ public class ExtraHddBodyEffectorTest extends AbstractYamlTest {
 
         parameterMap = TypeCoercions.coerce(parameterInputWithDoubleSizeInGB, Map.class);
 
-        transformed = ExtraHddBodyEffector.Body.transformMapToLocationCustomizerFields(parameterMap);
+        transformed = NewVolumeCustomizer.transformMapToVolume(parameterMap);
 
         assertEquals(((BlockDeviceOptions) ((MutableMap) transformed).asImmutableCopy().keySet().iterator().next()).getSizeInGb(), 4);
     }
@@ -153,7 +153,7 @@ public class ExtraHddBodyEffectorTest extends AbstractYamlTest {
 
         try {
             parameterMap = TypeCoercions.coerce(parameterInputWithMissingSizeInGb, Map.class);
-            ExtraHddBodyEffector.Body.transformMapToLocationCustomizerFields(parameterMap);
+            NewVolumeCustomizer.transformMapToVolume(parameterMap);
             Asserts.shouldHaveFailedPreviously("\"blockDevice\" should contain value for \"sizeInGb\"");
         } catch (Exception e) {
             Asserts.expectedFailureOfType(e, IllegalArgumentException.class);
@@ -177,7 +177,7 @@ public class ExtraHddBodyEffectorTest extends AbstractYamlTest {
 
         try {
             parameterMap = TypeCoercions.coerce(parameterInputWithNonIntegerSizeInGb, Map.class);
-            ExtraHddBodyEffector.Body.transformMapToLocationCustomizerFields(parameterMap);
+            NewVolumeCustomizer.transformMapToVolume(parameterMap);
             Asserts.shouldHaveFailedPreviously("Trying to set block device with not allowed sizeInGb value");
         } catch (Exception e) {
             Asserts.expectedFailureOfType(e, UnsupportedOperationException.class);
@@ -201,7 +201,7 @@ public class ExtraHddBodyEffectorTest extends AbstractYamlTest {
 
         try {
             parameterMap = TypeCoercions.coerce(parameterInputWithWrongValueTypes, Map.class);
-            ExtraHddBodyEffector.Body.transformMapToLocationCustomizerFields(parameterMap);
+            NewVolumeCustomizer.transformMapToVolume(parameterMap);
             Asserts.shouldHaveFailedPreviously();
         } catch (Exception e) {
             Asserts.expectedFailureOfType(e, ClassCastException.class);

--- a/blockstore/src/test/java/brooklyn/location/blockstore/gce/GoogleComputeEngineVolumeManagerLiveTest.java
+++ b/blockstore/src/test/java/brooklyn/location/blockstore/gce/GoogleComputeEngineVolumeManagerLiveTest.java
@@ -31,6 +31,11 @@ public class GoogleComputeEngineVolumeManagerLiveTest extends AbstractVolumeMana
     }
 
     @Override
+    protected char getDefaultDeviseSuffix() {
+        return 0;
+    }
+
+    @Override
     protected int getVolumeSize() {
         return 1;
     }

--- a/blockstore/src/test/java/brooklyn/location/blockstore/gce/GoogleComputeEngineVolumeManagerLiveTest.java
+++ b/blockstore/src/test/java/brooklyn/location/blockstore/gce/GoogleComputeEngineVolumeManagerLiveTest.java
@@ -31,8 +31,8 @@ public class GoogleComputeEngineVolumeManagerLiveTest extends AbstractVolumeMana
     }
 
     @Override
-    protected char getDefaultDeviseSuffix() {
-        return 0;
+    protected char getDefaultDeviceSuffix() {
+        throw new IllegalStateException("Figure out the correct device suffix");
     }
 
     @Override

--- a/blockstore/src/test/java/brooklyn/location/blockstore/gce/GoogleComputeEngineVolumeManagerLiveTest.java
+++ b/blockstore/src/test/java/brooklyn/location/blockstore/gce/GoogleComputeEngineVolumeManagerLiveTest.java
@@ -32,7 +32,7 @@ public class GoogleComputeEngineVolumeManagerLiveTest extends AbstractVolumeMana
 
     @Override
     protected char getDefaultDeviceSuffix() {
-        throw new IllegalStateException("Figure out the correct device suffix");
+        throw new IllegalStateException("Not implemented. Figure out the correct device suffix.");
     }
 
     @Override

--- a/blockstore/src/test/java/brooklyn/location/blockstore/openstack/OpenStackLocationConfig.java
+++ b/blockstore/src/test/java/brooklyn/location/blockstore/openstack/OpenStackLocationConfig.java
@@ -1,0 +1,68 @@
+package brooklyn.location.blockstore.openstack;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.brooklyn.core.internal.BrooklynProperties;
+import org.apache.brooklyn.location.jclouds.JcloudsLocation;
+import org.apache.brooklyn.util.text.Identifiers;
+
+import java.util.Map;
+
+public class OpenStackLocationConfig {
+
+
+    public static final String PROVIDER = "openstack-nova";
+    public static final String LOCATION_SPEC = PROVIDER;
+    public static final String NAMED_LOCATION = "OpenStackVolumeManagerLiveTest" + Identifiers.makeRandomId(4);
+    public static final String IMAGE_NAME_REGEX = "CentOS 7";
+
+    public static final String BROOKLYN_PROPERTIES_JCLOUDS_PREFIX = "brooklyn.location.jclouds.";
+
+    public static Map configMap;
+
+    public OpenStackLocationConfig() {
+        setConfigMap();
+    }
+
+    public static void addBrooklynProperties(BrooklynProperties properties) {
+        Object endpoint = properties.get(BROOKLYN_PROPERTIES_JCLOUDS_PREFIX+"openstack-nova.endpoint");
+        Object identity = properties.get(BROOKLYN_PROPERTIES_JCLOUDS_PREFIX+"openstack-cinder.identity");
+        Object credential = properties.get(BROOKLYN_PROPERTIES_JCLOUDS_PREFIX+"openstack-cinder.credential");
+        Object autoGenerateKeypairs = properties.get(BROOKLYN_PROPERTIES_JCLOUDS_PREFIX+"openstack-nova.auto-generate-keypairs");
+        Object keyPair = properties.get(BROOKLYN_PROPERTIES_JCLOUDS_PREFIX+"openstack-nova.keyPair");
+        Object privateKeyFile = properties.get(BROOKLYN_PROPERTIES_JCLOUDS_PREFIX+"openstack-nova.loginUser.privateKeyFile");
+        Object keystoneCredentialType = properties.get(BROOKLYN_PROPERTIES_JCLOUDS_PREFIX+"openstack-nova.jclouds.keystone.credential-type");
+
+        properties.put("brooklyn.location.named."+NAMED_LOCATION, PROVIDER+":"+endpoint);
+        properties.put("brooklyn.location.named."+NAMED_LOCATION+".identity", identity);
+        properties.put("brooklyn.location.named."+NAMED_LOCATION+".credential", credential);
+        properties.put("brooklyn.location.named."+NAMED_LOCATION+".region", "RegionOne");
+        properties.put("brooklyn.location.named."+NAMED_LOCATION+".jclouds.openstack-nova.auto-generate-keypairs", autoGenerateKeypairs);
+        properties.put("brooklyn.location.named."+NAMED_LOCATION+".keyPair", keyPair);
+        properties.put("brooklyn.location.named."+NAMED_LOCATION+".loginUser.privateKeyFile", privateKeyFile);
+        properties.put("brooklyn.location.named."+NAMED_LOCATION+".credential-type", keystoneCredentialType);
+
+    }
+
+    private static void setConfigMap() {
+        configMap = ImmutableMap.builder()
+                .put(JcloudsLocation.IMAGE_NAME_REGEX, IMAGE_NAME_REGEX)
+                .put("generate.hostname", true)
+                .put("loginUser", "centos")
+                .put("user", "amp")
+                .put("securityGroups", "VPN_local")
+                .put("auto-generate-keypairs", true)
+                .put("privateKeyFile", "~/.ssh/openstack.pem")
+                .put("templateOptions", ImmutableMap.of(
+                        "networks", ImmutableList.of("426bb8f6-c8c7-4f84-ad3c-19f66b28a288")
+                ))
+                .put("cloudMachineNamer", "org.apache.brooklyn.core.location.cloud.names.CustomMachineNamer")
+                .put("minRam", "2000")
+                .put("custom.machine.namer.machine", "QA-xxxx")
+                .build();
+    }
+
+    public static Map getConfigMap() {
+        return configMap;
+    }
+}

--- a/blockstore/src/test/java/brooklyn/location/blockstore/openstack/OpenStackNewVolumeCustomizerLiveTest.java
+++ b/blockstore/src/test/java/brooklyn/location/blockstore/openstack/OpenStackNewVolumeCustomizerLiveTest.java
@@ -1,5 +1,6 @@
 package brooklyn.location.blockstore.openstack;
 
+import brooklyn.location.blockstore.api.VolumeOptions;
 import com.google.common.collect.ImmutableList;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
@@ -33,25 +34,25 @@ public class OpenStackNewVolumeCustomizerLiveTest extends BrooklynAppLiveTestSup
         jcloudsLocation = mgmt.getLocationRegistry().getLocationManaged(locationConfig.NAMED_LOCATION, locationConfig.getConfigMap());
 
         OpenstackNewVolumeCustomizer customizer = new OpenstackNewVolumeCustomizer();
-        customizer.setVolumes(MutableList.<Map<?, ?>>of(
-                MutableMap.of("blockDevice", MutableMap.of(
-                        "sizeInGb", 3,
-                        "deviceSuffix", 'b',
-                        "deleteOnTermination", true
-                        ),
-                        "filesystem", MutableMap.of(
-                                "mountPoint", "/mount/brooklyn/b",
-                                "filesystemType", "ext3"
-                        )),
-                MutableMap.of("blockDevice", MutableMap.of(
-                        "sizeInGb", 3,
-                        "deviceSuffix", 'c',
-                        "deleteOnTermination", true
-                        ),
-                        "filesystem", MutableMap.of(
-                                "mountPoint", "/mount/brooklyn/c",
-                                "filesystemType", "ext3"
-                        ))));
+        customizer.setVolumes(MutableList.of(
+                VolumeOptions.<Map<String, Map<String, ?>>>fromMap(
+                        MutableMap.<String, Map<String,?>>of(
+                                "blockDevice", MutableMap.of(
+                                        "sizeInGb", 3,
+                                        "deviceSuffix", 'b',
+                                        "deleteOnTermination", true),
+                                "filesystem", MutableMap.<String, Object>of(
+                                        "mountPoint", "/mount/brooklyn/b",
+                                        "filesystemType", "ext3"))),
+                VolumeOptions.<String, Map<String,?>>fromMap(
+                        MutableMap.<String, Map<String, ?>>of(
+                                "blockDevice", MutableMap.<String, Object>of(
+                                    "sizeInGb", 3,
+                                    "deviceSuffix", 'c',
+                                    "deleteOnTermination", true),
+                                "filesystem", MutableMap.<String, Object>of(
+                                        "mountPoint", "/mount/brooklyn/c",
+                                        "filesystemType", "ext3")))));
 
         EmptySoftwareProcess entity = app.createAndManageChild(EntitySpec.create(EmptySoftwareProcess.class)
                 .configure(MachineEntity.PROVISIONING_PROPERTIES.subKey(JcloudsLocationConfig.JCLOUDS_LOCATION_CUSTOMIZERS.getName()),

--- a/blockstore/src/test/java/brooklyn/location/blockstore/openstack/OpenStackNewVolumeCustomizerLiveTest.java
+++ b/blockstore/src/test/java/brooklyn/location/blockstore/openstack/OpenStackNewVolumeCustomizerLiveTest.java
@@ -42,6 +42,15 @@ public class OpenStackNewVolumeCustomizerLiveTest extends BrooklynAppLiveTestSup
                         "filesystem", MutableMap.of(
                                 "mountPoint", "/mount/brooklyn/b",
                                 "filesystemType", "ext3"
+                        )),
+                MutableMap.of("blockDevice", MutableMap.of(
+                        "sizeInGb", 3,
+                        "deviceSuffix", 'c',
+                        "deleteOnTermination", true
+                        ),
+                        "filesystem", MutableMap.of(
+                                "mountPoint", "/mount/brooklyn/c",
+                                "filesystemType", "ext3"
                         ))));
 
         EmptySoftwareProcess entity = app.createAndManageChild(EntitySpec.create(EmptySoftwareProcess.class)

--- a/blockstore/src/test/java/brooklyn/location/blockstore/openstack/OpenStackNewVolumeCustomizerLiveTest.java
+++ b/blockstore/src/test/java/brooklyn/location/blockstore/openstack/OpenStackNewVolumeCustomizerLiveTest.java
@@ -19,6 +19,7 @@ import java.util.Map;
 
 import static org.testng.Assert.assertTrue;
 
+// Run with -da (disable assertions) die to bug in jclouds openstack-nova for not properly cloning template options
 public class OpenStackNewVolumeCustomizerLiveTest extends BrooklynAppLiveTestSupport {
 
     protected Location jcloudsLocation;

--- a/blockstore/src/test/java/brooklyn/location/blockstore/openstack/OpenStackNewVolumeCustomizerLiveTest.java
+++ b/blockstore/src/test/java/brooklyn/location/blockstore/openstack/OpenStackNewVolumeCustomizerLiveTest.java
@@ -1,0 +1,60 @@
+package brooklyn.location.blockstore.openstack;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.core.internal.BrooklynProperties;
+import org.apache.brooklyn.core.test.BrooklynAppLiveTestSupport;
+import org.apache.brooklyn.entity.machine.MachineEntity;
+import org.apache.brooklyn.entity.software.base.EmptySoftwareProcess;
+import org.apache.brooklyn.entity.software.base.lifecycle.NaiveScriptRunner;
+import org.apache.brooklyn.entity.software.base.lifecycle.ScriptHelper;
+import org.apache.brooklyn.location.jclouds.JcloudsLocationConfig;
+import org.apache.brooklyn.util.collections.MutableList;
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static org.testng.Assert.assertTrue;
+
+public class OpenStackNewVolumeCustomizerLiveTest extends BrooklynAppLiveTestSupport {
+
+    protected Location jcloudsLocation;
+    protected BrooklynProperties brooklynProperties;
+    protected OpenStackLocationConfig locationConfig;
+
+    @Test(groups = "Live")
+    public void testCustomizerCreatesAndAttachesNewVolumeOnProvisioningTime() {
+        locationConfig = new OpenStackLocationConfig();
+        brooklynProperties = mgmt.getBrooklynProperties();
+        locationConfig.addBrooklynProperties(brooklynProperties);
+
+        jcloudsLocation = mgmt.getLocationRegistry().getLocationManaged(locationConfig.NAMED_LOCATION, locationConfig.getConfigMap());
+
+        OpenstackNewVolumeCustomizer customizer = new OpenstackNewVolumeCustomizer();
+        customizer.setVolumes(MutableList.<Map<?, ?>>of(
+                MutableMap.of("blockDevice", MutableMap.of(
+                        "sizeInGb", 3,
+                        "deviceSuffix", 'b',
+                        "deleteOnTermination", true
+                        ),
+                        "filesystem", MutableMap.of(
+                                "mountPoint", "/mount/brooklyn/b",
+                                "filesystemType", "ext3"
+                        ))));
+
+        EmptySoftwareProcess entity = app.createAndManageChild(EntitySpec.create(EmptySoftwareProcess.class)
+                .configure(MachineEntity.PROVISIONING_PROPERTIES.subKey(JcloudsLocationConfig.JCLOUDS_LOCATION_CUSTOMIZERS.getName()),
+                        MutableList.of(customizer)));
+
+        app.start(ImmutableList.of(jcloudsLocation));
+
+        ScriptHelper scriptHelper = new ScriptHelper((NaiveScriptRunner) entity.getDriver(),
+                "Checking machine disks").body.append("df").gatherOutput();
+
+        scriptHelper.execute();
+        assertTrue(scriptHelper.getResultStdout().contains("/mount/brooklyn/b"));
+    }
+
+}

--- a/blockstore/src/test/java/brooklyn/location/blockstore/openstack/OpenStackVolumeManagerLiveTest.java
+++ b/blockstore/src/test/java/brooklyn/location/blockstore/openstack/OpenStackVolumeManagerLiveTest.java
@@ -50,7 +50,7 @@ public class OpenStackVolumeManagerLiveTest extends AbstractVolumeManagerLiveTes
     }
 
     @Override
-    protected char getDefaultDeviseSuffix() {
+    protected char getDefaultDeviceSuffix() {
         return 'b';
     }
 

--- a/blockstore/src/test/java/brooklyn/location/blockstore/openstack/OpenStackVolumeManagerLiveTest.java
+++ b/blockstore/src/test/java/brooklyn/location/blockstore/openstack/OpenStackVolumeManagerLiveTest.java
@@ -3,6 +3,7 @@ package brooklyn.location.blockstore.openstack;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
+import com.google.common.collect.ImmutableList;
 import org.apache.brooklyn.core.internal.BrooklynProperties;
 import org.apache.brooklyn.location.jclouds.JcloudsLocation;
 import org.apache.brooklyn.location.jclouds.JcloudsSshMachineLocation;
@@ -20,10 +21,10 @@ import brooklyn.location.blockstore.api.BlockDevice;
 public class OpenStackVolumeManagerLiveTest extends AbstractVolumeManagerLiveTest {
 
     public static final String PROVIDER = "openstack-nova";
-    public static final String ENDPOINT = "https://lon.identity.api.rackspacecloud.com/v2.0/";
+    public static final String ENDPOINT = "https://cloudsoft2-lon.openstack.blueboxgrid.com:5000/v2.0/";
     public static final String LOCATION_SPEC = PROVIDER+":"+ENDPOINT;
     public static final String NAMED_LOCATION = "OpenStackVolumeManagerLiveTest" + Identifiers.makeRandomId(4);
-    public static final String IMAGE_NAME_REGEX = ".*CentOS 6.*";
+    public static final String IMAGE_NAME_REGEX = "CentOS 7";
 
     @Override
     protected String getProvider() {
@@ -33,11 +34,20 @@ public class OpenStackVolumeManagerLiveTest extends AbstractVolumeManagerLiveTes
     @Override
     protected void addBrooklynProperties(BrooklynProperties props) {
         // re-using rackspace credentials, but pointing at it as a raw OpenStack nova endpoint
-        Object identity = props.get(BROOKLYN_PROPERTIES_JCLOUDS_PREFIX+"rackspace-cloudservers-uk.identity");
-        Object credential = props.get(BROOKLYN_PROPERTIES_JCLOUDS_PREFIX+"rackspace-cloudservers-uk.credential");
+        Object identity = props.get(BROOKLYN_PROPERTIES_JCLOUDS_PREFIX+"openstack-cinder.identity");
+        Object credential = props.get(BROOKLYN_PROPERTIES_JCLOUDS_PREFIX+"openstack-cinder.credential");
+//        Object autoGenerateKeypairs = props.get(BROOKLYN_PROPERTIES_JCLOUDS_PREFIX+"openstack-nova.auto-generate-keypairs");
+        Object keyPair = props.get(BROOKLYN_PROPERTIES_JCLOUDS_PREFIX+"openstack-nova.keyPair");
+        Object privateKeyFile = props.get(BROOKLYN_PROPERTIES_JCLOUDS_PREFIX+"openstack-nova.loginUser.privateKeyFile");
+//        Object keystoneCredentialType = props.get(BROOKLYN_PROPERTIES_JCLOUDS_PREFIX+"openstack-nova.keystone.credential-type");
         props.put("brooklyn.location.named."+NAMED_LOCATION, LOCATION_SPEC);
         props.put("brooklyn.location.named."+NAMED_LOCATION+".identity", identity);
         props.put("brooklyn.location.named."+NAMED_LOCATION+".credential", credential);
+        props.put("brooklyn.location.named."+NAMED_LOCATION+".region", "RegionOne");
+//        props.put("brooklyn.location.named."+NAMED_LOCATION+".jclouds.openstack-nova.auto-generate-keypairs", autoGenerateKeypairs);
+        props.put("brooklyn.location.named."+NAMED_LOCATION+".keyPair", keyPair);
+        props.put("brooklyn.location.named."+NAMED_LOCATION+".loginUser.privateKeyFile", privateKeyFile);
+//        props.put("brooklyn.location.named."+NAMED_LOCATION+".credential-type", keystoneCredentialType);
     }
 
     @Override
@@ -72,6 +82,13 @@ public class OpenStackVolumeManagerLiveTest extends AbstractVolumeManagerLiveTes
         // TODO Wanted to specify hardware id, but this failed; and wanted to force no imageId (in case specified in brooklyn.properties)
         return (JcloudsSshMachineLocation) jcloudsLocation.obtain(ImmutableMap.builder()
                 .put(JcloudsLocation.IMAGE_NAME_REGEX, IMAGE_NAME_REGEX)
+                .put("generate.hostname", true)
+                .put("loginUser", "centos")
+                .put("user", "amp")
+                .put("securityGroups", "VPN_local")
+                .put("templateOptions", ImmutableMap.of(
+                        "networks", ImmutableList.of("426bb8f6-c8c7-4f84-ad3c-19f66b28a288")
+                ))
                 .build());
     }
 }

--- a/blockstore/src/test/java/brooklyn/location/blockstore/openstack/OpenStackVolumeManagerLiveTest.java
+++ b/blockstore/src/test/java/brooklyn/location/blockstore/openstack/OpenStackVolumeManagerLiveTest.java
@@ -1,58 +1,42 @@
 package brooklyn.location.blockstore.openstack;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
-
-import com.google.common.collect.ImmutableList;
+import brooklyn.location.blockstore.AbstractVolumeManagerLiveTest;
+import brooklyn.location.blockstore.api.BlockDevice;
+import com.google.common.base.Optional;
 import org.apache.brooklyn.core.internal.BrooklynProperties;
 import org.apache.brooklyn.location.jclouds.JcloudsLocation;
 import org.apache.brooklyn.location.jclouds.JcloudsSshMachineLocation;
-import org.apache.brooklyn.util.text.Identifiers;
 import org.jclouds.openstack.cinder.v1.domain.Volume;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableMap;
-
-import brooklyn.location.blockstore.AbstractVolumeManagerLiveTest;
-import brooklyn.location.blockstore.api.BlockDevice;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 
 @Test
 public class OpenStackVolumeManagerLiveTest extends AbstractVolumeManagerLiveTest {
 
-    public static final String PROVIDER = "openstack-nova";
-    public static final String ENDPOINT = "https://cloudsoft2-lon.openstack.blueboxgrid.com:5000/v2.0/";
-    public static final String LOCATION_SPEC = PROVIDER+":"+ENDPOINT;
-    public static final String NAMED_LOCATION = "OpenStackVolumeManagerLiveTest" + Identifiers.makeRandomId(4);
-    public static final String IMAGE_NAME_REGEX = "CentOS 7";
+    public static OpenStackLocationConfig locationConfig;
+
+    @BeforeMethod(alwaysRun=true)
+    public void setUp() throws Exception {
+        super.setUp();
+        locationConfig = new OpenStackLocationConfig();
+    }
 
     @Override
     protected String getProvider() {
-        return PROVIDER;
+        return locationConfig.PROVIDER;
     }
 
     @Override
     protected void addBrooklynProperties(BrooklynProperties props) {
-        // re-using rackspace credentials, but pointing at it as a raw OpenStack nova endpoint
-        Object identity = props.get(BROOKLYN_PROPERTIES_JCLOUDS_PREFIX+"openstack-cinder.identity");
-        Object credential = props.get(BROOKLYN_PROPERTIES_JCLOUDS_PREFIX+"openstack-cinder.credential");
-        Object autoGenerateKeypairs = props.get(BROOKLYN_PROPERTIES_JCLOUDS_PREFIX+"openstack-nova.auto-generate-keypairs");
-        Object keyPair = props.get(BROOKLYN_PROPERTIES_JCLOUDS_PREFIX+"openstack-nova.keyPair");
-        Object privateKeyFile = props.get(BROOKLYN_PROPERTIES_JCLOUDS_PREFIX+"openstack-nova.loginUser.privateKeyFile");
-        Object keystoneCredentialType = props.get(BROOKLYN_PROPERTIES_JCLOUDS_PREFIX+"openstack-nova.jclouds.keystone.credential-type");
-        props.put("brooklyn.location.named."+NAMED_LOCATION, LOCATION_SPEC);
-        props.put("brooklyn.location.named."+NAMED_LOCATION+".identity", identity);
-        props.put("brooklyn.location.named."+NAMED_LOCATION+".credential", credential);
-        props.put("brooklyn.location.named."+NAMED_LOCATION+".region", "RegionOne");
-        props.put("brooklyn.location.named."+NAMED_LOCATION+".jclouds.openstack-nova.auto-generate-keypairs", autoGenerateKeypairs);
-        props.put("brooklyn.location.named."+NAMED_LOCATION+".keyPair", keyPair);
-        props.put("brooklyn.location.named."+NAMED_LOCATION+".loginUser.privateKeyFile", privateKeyFile);
-        props.put("brooklyn.location.named."+NAMED_LOCATION+".credential-type", keystoneCredentialType);
+        locationConfig.addBrooklynProperties(props);
     }
 
     @Override
     protected JcloudsLocation createJcloudsLocation() {
-        return (JcloudsLocation) ctx.getLocationRegistry().getLocationManaged("named:"+NAMED_LOCATION);
+        return (JcloudsLocation) ctx.getLocationRegistry().getLocationManaged("named:"+locationConfig.NAMED_LOCATION);
     }
     
     @Override
@@ -63,6 +47,11 @@ public class OpenStackVolumeManagerLiveTest extends AbstractVolumeManagerLiveTes
     @Override
     protected String getDefaultAvailabilityZone() {
         return null;
+    }
+
+    @Override
+    protected char getDefaultDeviseSuffix() {
+        return 'b';
     }
 
     @Override
@@ -79,21 +68,6 @@ public class OpenStackVolumeManagerLiveTest extends AbstractVolumeManagerLiveTes
     
     @Override
     protected JcloudsSshMachineLocation createJcloudsMachine() throws Exception {
-        // TODO Wanted to specify hardware id, but this failed; and wanted to force no imageId (in case specified in brooklyn.properties)
-        return (JcloudsSshMachineLocation) jcloudsLocation.obtain(ImmutableMap.builder()
-                .put(JcloudsLocation.IMAGE_NAME_REGEX, IMAGE_NAME_REGEX)
-                .put("generate.hostname", true)
-                .put("loginUser", "centos")
-                .put("user", "amp")
-                .put("securityGroups", "VPN_local")
-                .put("auto-generate-keypairs", true)
-                .put("privateKeyFile", "~/.ssh/openstack.pem")
-                .put("templateOptions", ImmutableMap.of(
-                        "networks", ImmutableList.of("426bb8f6-c8c7-4f84-ad3c-19f66b28a288")
-                ))
-                .put("cloudMachineNamer", "org.apache.brooklyn.core.location.cloud.names.CustomMachineNamer")
-                .put("minRam", "2000")
-                .put("custom.machine.namer.machine", "QA-valentin-xxxx")
-                .build());
+        return (JcloudsSshMachineLocation) jcloudsLocation.obtain(locationConfig.getConfigMap());
     }
 }

--- a/blockstore/src/test/java/brooklyn/location/blockstore/openstack/OpenStackVolumeManagerLiveTest.java
+++ b/blockstore/src/test/java/brooklyn/location/blockstore/openstack/OpenStackVolumeManagerLiveTest.java
@@ -36,18 +36,18 @@ public class OpenStackVolumeManagerLiveTest extends AbstractVolumeManagerLiveTes
         // re-using rackspace credentials, but pointing at it as a raw OpenStack nova endpoint
         Object identity = props.get(BROOKLYN_PROPERTIES_JCLOUDS_PREFIX+"openstack-cinder.identity");
         Object credential = props.get(BROOKLYN_PROPERTIES_JCLOUDS_PREFIX+"openstack-cinder.credential");
-//        Object autoGenerateKeypairs = props.get(BROOKLYN_PROPERTIES_JCLOUDS_PREFIX+"openstack-nova.auto-generate-keypairs");
+        Object autoGenerateKeypairs = props.get(BROOKLYN_PROPERTIES_JCLOUDS_PREFIX+"openstack-nova.auto-generate-keypairs");
         Object keyPair = props.get(BROOKLYN_PROPERTIES_JCLOUDS_PREFIX+"openstack-nova.keyPair");
         Object privateKeyFile = props.get(BROOKLYN_PROPERTIES_JCLOUDS_PREFIX+"openstack-nova.loginUser.privateKeyFile");
-//        Object keystoneCredentialType = props.get(BROOKLYN_PROPERTIES_JCLOUDS_PREFIX+"openstack-nova.keystone.credential-type");
+        Object keystoneCredentialType = props.get(BROOKLYN_PROPERTIES_JCLOUDS_PREFIX+"openstack-nova.jclouds.keystone.credential-type");
         props.put("brooklyn.location.named."+NAMED_LOCATION, LOCATION_SPEC);
         props.put("brooklyn.location.named."+NAMED_LOCATION+".identity", identity);
         props.put("brooklyn.location.named."+NAMED_LOCATION+".credential", credential);
         props.put("brooklyn.location.named."+NAMED_LOCATION+".region", "RegionOne");
-//        props.put("brooklyn.location.named."+NAMED_LOCATION+".jclouds.openstack-nova.auto-generate-keypairs", autoGenerateKeypairs);
+        props.put("brooklyn.location.named."+NAMED_LOCATION+".jclouds.openstack-nova.auto-generate-keypairs", autoGenerateKeypairs);
         props.put("brooklyn.location.named."+NAMED_LOCATION+".keyPair", keyPair);
         props.put("brooklyn.location.named."+NAMED_LOCATION+".loginUser.privateKeyFile", privateKeyFile);
-//        props.put("brooklyn.location.named."+NAMED_LOCATION+".credential-type", keystoneCredentialType);
+        props.put("brooklyn.location.named."+NAMED_LOCATION+".credential-type", keystoneCredentialType);
     }
 
     @Override
@@ -86,9 +86,14 @@ public class OpenStackVolumeManagerLiveTest extends AbstractVolumeManagerLiveTes
                 .put("loginUser", "centos")
                 .put("user", "amp")
                 .put("securityGroups", "VPN_local")
+                .put("auto-generate-keypairs", true)
+                .put("privateKeyFile", "~/.ssh/openstack.pem")
                 .put("templateOptions", ImmutableMap.of(
                         "networks", ImmutableList.of("426bb8f6-c8c7-4f84-ad3c-19f66b28a288")
                 ))
+                .put("cloudMachineNamer", "org.apache.brooklyn.core.location.cloud.names.CustomMachineNamer")
+                .put("minRam", "2000")
+                .put("custom.machine.namer.machine", "QA-valentin-xxxx")
                 .build());
     }
 }

--- a/blockstore/src/test/java/brooklyn/location/blockstore/openstack/RackspaceVolumeManagerLiveTest.java
+++ b/blockstore/src/test/java/brooklyn/location/blockstore/openstack/RackspaceVolumeManagerLiveTest.java
@@ -44,8 +44,8 @@ public class RackspaceVolumeManagerLiveTest extends AbstractVolumeManagerLiveTes
     }
 
     @Override
-    protected char getDefaultDeviseSuffix() {
-        return 0;
+    protected char getDefaultDeviceSuffix() {
+        throw new IllegalStateException("Figure out the correct device suffix");
     }
 
     @Override

--- a/blockstore/src/test/java/brooklyn/location/blockstore/openstack/RackspaceVolumeManagerLiveTest.java
+++ b/blockstore/src/test/java/brooklyn/location/blockstore/openstack/RackspaceVolumeManagerLiveTest.java
@@ -45,7 +45,7 @@ public class RackspaceVolumeManagerLiveTest extends AbstractVolumeManagerLiveTes
 
     @Override
     protected char getDefaultDeviceSuffix() {
-        throw new IllegalStateException("Figure out the correct device suffix");
+        throw new IllegalStateException("Not implemented. Figure out the correct device suffix.");
     }
 
     @Override

--- a/blockstore/src/test/java/brooklyn/location/blockstore/openstack/RackspaceVolumeManagerLiveTest.java
+++ b/blockstore/src/test/java/brooklyn/location/blockstore/openstack/RackspaceVolumeManagerLiveTest.java
@@ -44,6 +44,11 @@ public class RackspaceVolumeManagerLiveTest extends AbstractVolumeManagerLiveTes
     }
 
     @Override
+    protected char getDefaultDeviseSuffix() {
+        return 0;
+    }
+
+    @Override
     protected void assertVolumeAvailable(BlockDevice device) {
         Volume volume = ((AbstractOpenstackVolumeManager)volumeManager).describeVolume(device);
         assertNotNull(volume);


### PR DESCRIPTION
In order to attach disk during provisioning time, one can use these properties in the yaml:
```
provisioning.properties:
  customizers:
  - $brooklyn:object:
      type: io.brooklyn.blockstore.brooklyn-blockstore:brooklyn.location.blockstore.openstack.OpenstackNewVolumeCustomizer
      object.fields:
        volumes:
        - blockDevice:
            sizeInGb: 3
            deviceSuffix: 'b'
            deleteOnTermination: false
            tags:
              brooklyn: br-example-val-test-1
         filesystem:
           mountPoint: /mount/brooklyn/b
           filesystemType: ext3
```

Important notice is that KVM is configured as the default hypervisor for OpenStack which means that the defined device name will be of type ` /dev/vd*`. This means that the device suffix must be set as the next letter in alphabetical order from the existing device names on the VM.

To attach an effector for creating extra hdd, you should add this initializer to the yaml:

```
  brooklyn.initializers:
    - type: io.brooklyn.blockstore.brooklyn-blockstore:brooklyn.location.blockstore.effectors.ExtraHddBodyEffector
```

As a parameter for the effector, you should use a map of this type:
```
{
	"blockDevice": {
		"sizeInGb": 1,
		"deviceSuffix": "c",
		"deleteOnTermination": false,
		"tags": {
			"brooklyn": "br-example-val-test-1"
		}
	},
	"filesystem": {
		"mountPoint": "/mount/brooklyn/c",
		"filesystemType": "ext3"
	}
}
```
