### PR TITLE
Change version to 0.6.0-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ of OSGi):
 
     BROOKLYN_HOME=~/repos/apache/brooklyn/brooklyn-dist/dist/target/brooklyn-dist/brooklyn/
     BROOKLYN_BLOCKSTORE_REPO=~/repos/cloudsoft/brooklyn-blockstore
-    BROOKLYN_BLOCKSTORE_VERSION=0.5.0-SNAPSHOT
+    BROOKLYN_BLOCKSTORE_VERSION=0.6.0-SNAPSHOT
     
     cp ${BROOKLYN_BLOCKSTORE_REPO}/blockstore/target/brooklyn-blockstore-${BROOKLYN_BLOCKSTORE_VERSION}.jar ${BROOKLYN_HOME}/lib/dropins/
 

--- a/blockstore/pom.xml
+++ b/blockstore/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.brooklyn.blockstore</groupId>
         <artifactId>brooklyn-blockstore-parent</artifactId>
-        <version>0.5.0-SNAPSHOT</version>  <!-- BROOKLYN_BLOCKSTORE_VERSION -->
+        <version>0.6.0-SNAPSHOT</version>  <!-- BROOKLYN_BLOCKSTORE_VERSION -->
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.brooklyn.blockstore</groupId>
     <artifactId>brooklyn-blockstore-parent</artifactId>
-    <version>0.5.0-SNAPSHOT</version>  <!-- BROOKLYN_BLOCKSTORE_VERSION -->
+    <version>0.6.0-SNAPSHOT</version>  <!-- BROOKLYN_BLOCKSTORE_VERSION -->
     <packaging>pom</packaging>
 
     <name>Brooklyn Blockstore - Parent</name>


### PR DESCRIPTION
Now that we've switched master to brooklyn 0.11.0-SNAPSHOT, we also need to bump the brooklyn-blockstore version number.

I'll also create a 0.5.x branch, which will depend on brooklyn 0.10.0-SNAPSHOT (and then 0.10.0 once that is released). We'll release 0.5.0 once brooklyn 0.10.0 is released.