### PR TITLE
Remove amp-jumphost dependency

### DIFF
--- a/blockstore/pom.xml
+++ b/blockstore/pom.xml
@@ -47,12 +47,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.cloudsoft.amp.jumphost</groupId>
-            <artifactId>jumphost-ssh-client</artifactId>
-            <version>${amp-jumphost.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.brooklyn</groupId>
             <artifactId>brooklyn-test-support</artifactId>
             <version>${brooklyn.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,6 @@
     </modules>
 
     <properties>
-        <amp-jumphost.version>1.0.0-SNAPSHOT</amp-jumphost.version><!-- JUMPHOST_VERSION -->
         <vcloud-director.version>2.0.0-20161213.1259</vcloud-director.version>
     </properties>
 


### PR DESCRIPTION
Dependency is never used. In this open-source project, we should not be depending on this closed-source library.

@iyovcheva @bostko any reason this dependency is needed (it was added in the commit 0a8333bdc32a5b68b73e780642d06918924c16ca, "VcloudVolumeManager").