### PR TITLE
Adds `volumeType` to device options, pass to AWS

### DIFF
--- a/blockstore/src/main/java/brooklyn/location/blockstore/BlockDeviceOptions.java
+++ b/blockstore/src/main/java/brooklyn/location/blockstore/BlockDeviceOptions.java
@@ -9,6 +9,7 @@ import org.apache.brooklyn.util.core.flags.TypeCoercions;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.Maps;
+import org.apache.brooklyn.util.guava.Maybe;
 
 public class BlockDeviceOptions {
 
@@ -18,6 +19,7 @@ public class BlockDeviceOptions {
     private int sizeInGb;
     private char deviceSuffix = 'h';
     private boolean deleteOnTermination;
+    private Maybe<String> volumeType = Maybe.absent();
 
     // For more convenient yaml input
     public static BlockDeviceOptions fromMap(Map<String, ?> map) {
@@ -62,6 +64,9 @@ public class BlockDeviceOptions {
         if (map.containsKey("deleteOnTermination")) {
             result.deleteOnTermination = (Boolean) checkNotNull(map.get("deleteOnTermination"), "deleteOnTermination");
         }
+        if (map.containsKey("volumeType")) {
+            result.volumeType = Maybe.of(checkNotNull(map.get("volumeType"), "volumeType").toString());
+        }
         return result;
     }
     
@@ -72,7 +77,8 @@ public class BlockDeviceOptions {
     			.tags(other.tags)
     			.sizeInGb(other.sizeInGb)
     			.deviceSuffix(other.deviceSuffix)
-    			.deleteOnTermination(other.deleteOnTermination);
+                .deleteOnTermination(other.deleteOnTermination)
+                .volumeType(other.volumeType);
     }
     
     public String getName() {
@@ -115,6 +121,16 @@ public class BlockDeviceOptions {
         return this;
     }
 
+    public BlockDeviceOptions volumeType(String volumeType) {
+        this.volumeType = Maybe.of(checkNotNull(volumeType, "volumeType"));
+        return this;
+    }
+
+    public BlockDeviceOptions volumeType(Maybe<String> volumeType) {
+        this.volumeType = checkNotNull(volumeType, "volumeType");
+        return this;
+    }
+
     public String getZone() {
         return zone;
     }
@@ -139,6 +155,10 @@ public class BlockDeviceOptions {
         return deleteOnTermination;
     }
 
+    public Maybe<String> getVolumeType() {
+        return volumeType;
+    }
+
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
@@ -148,6 +168,7 @@ public class BlockDeviceOptions {
                 .add("sizeInGb", sizeInGb)
                 .add("deviceSuffix", deviceSuffix)
                 .add("deleteOnTermination", deleteOnTermination)
+                .add("volumeType", volumeType)
                 .toString();
     }
 }

--- a/blockstore/src/main/java/brooklyn/location/blockstore/ec2/Ec2VolumeManager.java
+++ b/blockstore/src/main/java/brooklyn/location/blockstore/ec2/Ec2VolumeManager.java
@@ -14,6 +14,7 @@ import org.jclouds.ec2.domain.Attachment;
 import org.jclouds.ec2.domain.Volume;
 import org.jclouds.ec2.features.ElasticBlockStoreApi;
 import org.jclouds.ec2.features.TagApi;
+import org.jclouds.ec2.options.CreateVolumeOptions;
 import org.jclouds.ec2.options.DetachVolumeOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,7 +56,11 @@ public class Ec2VolumeManager extends AbstractVolumeManager {
         ElasticBlockStoreApi ebsApi = getEbsApi(location);
         TagApi tagApi = getTagApi(location);
 
-        Volume volume = ebsApi.createVolumeInAvailabilityZone(options.getZone(), options.getSizeInGb());
+        CreateVolumeOptions cvo = CreateVolumeOptions.Builder.withSize(options.getSizeInGb());
+        if (options.getVolumeType().isPresent())
+        cvo = cvo.volumeType(options.getVolumeType().get());
+
+        Volume volume = ebsApi.createVolumeInAvailabilityZone(options.getZone(), cvo);
         if (options.hasTags()) {
             tagApi.applyToResources(options.getTags(), ImmutableList.of(volume.getId()));
         }


### PR DESCRIPTION
This allows volumes to be specified as `gp2` (i.e. SSD) on AWS EBS