### PR TITLE
Test volume type

### DIFF
--- a/blockstore/src/main/java/brooklyn/location/blockstore/BlockDeviceOptions.java
+++ b/blockstore/src/main/java/brooklyn/location/blockstore/BlockDeviceOptions.java
@@ -19,6 +19,8 @@ public class BlockDeviceOptions {
     private int sizeInGb;
     private char deviceSuffix = 'h';
     private boolean deleteOnTermination;
+    private Maybe<Integer> iops = Maybe.absent();
+    private Maybe<Boolean> encrypted = Maybe.absent();
     private Maybe<String> volumeType = Maybe.absent();
 
     // For more convenient yaml input
@@ -64,6 +66,12 @@ public class BlockDeviceOptions {
         if (map.containsKey("deleteOnTermination")) {
             result.deleteOnTermination = (Boolean) checkNotNull(map.get("deleteOnTermination"), "deleteOnTermination");
         }
+        if (map.containsKey("iops")) {
+            result.iops = Maybe.of(TypeCoercions.coerce(checkNotNull(map.get("iops"), "iops"), Integer.class));
+        }
+        if (map.containsKey("encrypted")) {
+            result.encrypted = Maybe.of(TypeCoercions.coerce(checkNotNull(map.get("encrypted"), "encrypted"), Boolean.class));
+        }
         if (map.containsKey("volumeType")) {
             result.volumeType = Maybe.of(checkNotNull(map.get("volumeType"), "volumeType").toString());
         }
@@ -78,6 +86,8 @@ public class BlockDeviceOptions {
                 .sizeInGb(other.sizeInGb)
                 .deviceSuffix(other.deviceSuffix)
                 .deleteOnTermination(other.deleteOnTermination)
+                .iops(other.iops)
+                .encrypted(other.encrypted)
                 .volumeType(other.volumeType);
     }
     
@@ -121,6 +131,26 @@ public class BlockDeviceOptions {
         return this;
     }
 
+    public BlockDeviceOptions iops(Integer iops) {
+        this.iops = Maybe.of(checkNotNull(iops, "iops"));
+        return this;
+    }
+
+    public BlockDeviceOptions iops(Maybe<Integer> iops) {
+        this.iops = checkNotNull(iops, "iops");
+        return this;
+    }
+
+    public BlockDeviceOptions encrypted(Boolean encrypted) {
+        this.encrypted = Maybe.of(checkNotNull(encrypted, "encrypted"));
+        return this;
+    }
+
+    public BlockDeviceOptions encrypted(Maybe<Boolean> encrypted) {
+        this.encrypted = checkNotNull(encrypted);
+        return this;
+    }
+
     public BlockDeviceOptions volumeType(String volumeType) {
         this.volumeType = Maybe.of(checkNotNull(volumeType, "volumeType"));
         return this;
@@ -155,6 +185,14 @@ public class BlockDeviceOptions {
         return deleteOnTermination;
     }
 
+    public Maybe<Integer> getIops() {
+        return iops;
+    }
+
+    public Maybe<Boolean> getEncrypted() {
+        return encrypted;
+    }
+
     public Maybe<String> getVolumeType() {
         return volumeType;
     }
@@ -168,6 +206,8 @@ public class BlockDeviceOptions {
                 .add("sizeInGb", sizeInGb)
                 .add("deviceSuffix", deviceSuffix)
                 .add("deleteOnTermination", deleteOnTermination)
+                .add("iops", iops)
+                .add("encrypted", encrypted)
                 .add("volumeType", volumeType)
                 .toString();
     }

--- a/blockstore/src/main/java/brooklyn/location/blockstore/BlockDeviceOptions.java
+++ b/blockstore/src/main/java/brooklyn/location/blockstore/BlockDeviceOptions.java
@@ -71,12 +71,12 @@ public class BlockDeviceOptions {
     }
     
     public static BlockDeviceOptions copy(BlockDeviceOptions other) {
-    	return new BlockDeviceOptions()
-    			.name(other.name)
-    			.zone(other.zone)
-    			.tags(other.tags)
-    			.sizeInGb(other.sizeInGb)
-    			.deviceSuffix(other.deviceSuffix)
+        return new BlockDeviceOptions()
+                .name(other.name)
+                .zone(other.zone)
+                .tags(other.tags)
+                .sizeInGb(other.sizeInGb)
+                .deviceSuffix(other.deviceSuffix)
                 .deleteOnTermination(other.deleteOnTermination)
                 .volumeType(other.volumeType);
     }

--- a/blockstore/src/main/java/brooklyn/location/blockstore/ec2/Ec2VolumeManager.java
+++ b/blockstore/src/main/java/brooklyn/location/blockstore/ec2/Ec2VolumeManager.java
@@ -57,6 +57,12 @@ public class Ec2VolumeManager extends AbstractVolumeManager {
         TagApi tagApi = getTagApi(location);
 
         CreateVolumeOptions cvo = CreateVolumeOptions.Builder.withSize(options.getSizeInGb());
+        if (options.getIops().isPresent()) {
+            cvo = cvo.withIops(options.getIops().get());
+        }
+        if (options.getEncrypted().isPresent()) {
+            cvo = cvo.isEncrypted(options.getEncrypted().get());
+        }
         if (options.getVolumeType().isPresent()) {
             cvo = cvo.volumeType(options.getVolumeType().get());
         }

--- a/blockstore/src/main/java/brooklyn/location/blockstore/ec2/Ec2VolumeManager.java
+++ b/blockstore/src/main/java/brooklyn/location/blockstore/ec2/Ec2VolumeManager.java
@@ -57,9 +57,10 @@ public class Ec2VolumeManager extends AbstractVolumeManager {
         TagApi tagApi = getTagApi(location);
 
         CreateVolumeOptions cvo = CreateVolumeOptions.Builder.withSize(options.getSizeInGb());
-        if (options.getVolumeType().isPresent())
-        cvo = cvo.volumeType(options.getVolumeType().get());
-
+        if (options.getVolumeType().isPresent()) {
+            cvo = cvo.volumeType(options.getVolumeType().get());
+        }
+        
         Volume volume = ebsApi.createVolumeInAvailabilityZone(options.getZone(), cvo);
         if (options.hasTags()) {
             tagApi.applyToResources(options.getTags(), ImmutableList.of(volume.getId()));

--- a/blockstore/src/main/java/brooklyn/location/blockstore/gce/GoogleComputeEngineVolumeCustomizer.java
+++ b/blockstore/src/main/java/brooklyn/location/blockstore/gce/GoogleComputeEngineVolumeCustomizer.java
@@ -12,12 +12,12 @@ public class GoogleComputeEngineVolumeCustomizer {
 
     // FIXME This is Alex's guess! Untested.
     // FIXME How to set capacities, rather than just number of disks?
-	// FIXME There is no GoogleComputeEngineTemplateOptions.disks!
+    // FIXME There is no GoogleComputeEngineTemplateOptions.disks!
     public static JcloudsLocationCustomizer withNewVolume(final List<Integer> capacities) {
         return new BasicJcloudsLocationCustomizer() {
             @Override
             public void customize(JcloudsLocation location, ComputeService computeService, TemplateOptions templateOptions) {
-            	throw new UnsupportedOperationException("Unsupported for GCE");
+                throw new UnsupportedOperationException("Unsupported for GCE");
 //                Set<PersistentDisk> disks = MutableSet.of();
 //                for (int i=0; i<capacities.size(); i++) {
 //                    disks.add(new PersistentDisk(Mode.READ_WRITE, null, "sd"+(char)('f'+i), true, true));

--- a/blockstore/src/main/java/brooklyn/location/blockstore/gce/GoogleComputeEngineVolumeManager.java
+++ b/blockstore/src/main/java/brooklyn/location/blockstore/gce/GoogleComputeEngineVolumeManager.java
@@ -59,8 +59,8 @@ public class GoogleComputeEngineVolumeManager extends AbstractVolumeManager {
         String name = getOrMakeName(location, options);
 
         DiskCreationOptions diskOptions = new DiskCreationOptions.Builder()
-		        .sizeGb(options.getSizeInGb())
-		        .build();
+                .sizeGb(options.getSizeInGb())
+                .build();
         Operation operation = diskApi.create(name, diskOptions);
         waitForOperationToBeDone(computeApi, operation);
 
@@ -104,7 +104,7 @@ public class GoogleComputeEngineVolumeManager extends AbstractVolumeManager {
         String zone = getZoneFromDisk(disk);
         InstanceApi instanceApi = computeApi.instancesInZone(zone);
 
-		Operation operation = instanceApi.detachDisk(
+        Operation operation = instanceApi.detachDisk(
                 device.getMachine().getNode().getName(), 
                 String.valueOf(device.getDeviceSuffix()));
         waitForOperationToBeDone(computeApi, operation);
@@ -122,7 +122,7 @@ public class GoogleComputeEngineVolumeManager extends AbstractVolumeManager {
         String zone = getZoneFromDisk(disk);
         DiskApi diskApi = computeApi.disksInZone(zone);
 
-		Operation operation = diskApi.delete(device.getId());
+        Operation operation = diskApi.delete(device.getId());
         waitForOperationToBeDone(computeApi, operation);
     }
 
@@ -137,7 +137,7 @@ public class GoogleComputeEngineVolumeManager extends AbstractVolumeManager {
         GoogleComputeEngineApi computeApi = getGoogleComputeEngineApi(device.getLocation());
         String zone = getZoneFromDisk(disk);
         DiskApi diskApi = computeApi.disksInZone(zone);
-		return diskApi.get(device.getId());
+        return diskApi.get(device.getId());
     }
 
     private GoogleComputeEngineApi getGoogleComputeEngineApi(JcloudsLocation location) {
@@ -170,7 +170,7 @@ public class GoogleComputeEngineVolumeManager extends AbstractVolumeManager {
                 .until(new Callable<Boolean>() {
                     @Override
                     public Boolean call() throws Exception {
-                    	Operation current = api.operations().get(operation.selfLink());
+                        Operation current = api.operations().get(operation.selfLink());
                         latest.set(current);
                         return current.status() == Operation.Status.DONE;
                     }

--- a/blockstore/src/test/java/brooklyn/location/blockstore/ec2/Ec2VolumeManagerLiveTest.java
+++ b/blockstore/src/test/java/brooklyn/location/blockstore/ec2/Ec2VolumeManagerLiveTest.java
@@ -1,20 +1,48 @@
 package brooklyn.location.blockstore.ec2;
 
-import brooklyn.location.blockstore.AbstractVolumeManagerLiveTest;
-import brooklyn.location.blockstore.api.BlockDevice;
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableMap;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+import java.util.Map;
+
 import org.apache.brooklyn.location.jclouds.JcloudsLocation;
 import org.apache.brooklyn.location.jclouds.JcloudsSshMachineLocation;
 import org.jclouds.ec2.domain.Volume;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
+
+import brooklyn.location.blockstore.AbstractVolumeManagerLiveTest;
+import brooklyn.location.blockstore.BlockDeviceOptions;
+import brooklyn.location.blockstore.api.BlockDevice;
 
 @Test(groups = "Live")
 public class Ec2VolumeManagerLiveTest extends AbstractVolumeManagerLiveTest {
 
+    /*
+     * TODO Test failure in testMoveMountedVolumeToAnotherMachine, with the below error:
+       2018-05-14 09:17:18,675 INFO  - Creating and mounting device on machine1: SshMachineLocation[52.213.224.120:aledsage@ec2-52-213-224-120.eu-west-1.compute.amazonaws.com/52.213.224.120:22(id=le9rlzj6mt)]
+       2018-05-14 09:17:56,834 INFO  - Unmounting filesystem: MountedBlockDeviceImpl{id=vol-01234567890012345, machine=SshMachineLocation[52.213.224.120:aledsage@ec2-52-213-224-120.eu-west-1.compute.amazonaws.com/52.213.224.120:22(id=le9rlzj6mt)], deviceName=/dev/sdh, mountPoint=/var/opt/mountpoint}
+       2018-05-14 09:18:57,765 ERROR - Volume MountedBlockDeviceImpl{id=vol-01234567890012345, machine=SshMachineLocation[52.213.224.120:aledsage@ec2-52-213-224-120.eu-west-1.compute.amazonaws.com/52.213.224.120:22(id=le9rlzj6mt)], deviceName=/dev/sdh, mountPoint=/var/opt/mountpoint} still not available. Last known was: Volume [attachments=[Attachment [region=eu-west-1, volumeId=vol-01234567890123456, instanceId=i-012345678901234567, device=/dev/sdh, attachTime=Mon May 14 09:17:24 BST 2018, status=detaching]], availabilityZone=eu-west-1a, createTime=Mon May 14 09:17:19 BST 2018, id=vol-01234567890012345, region=eu-west-1, size=1, snapshotId=null, status=in-use, volumeType=null, iops=null, encrypted=false]; continuing
+       2018-05-14 09:18:57,765 INFO  - Remounting BlockDeviceImpl{id=vol-01234567890012345, location=JcloudsLocation[aws-ec2:eu-west-1a:XXXXXXXXXXXXXXXXXXXX@xxxxxxxxxx]} on machine2: SshMachineLocation[52.49.236.134:aledsage@ec2-52-49-236-134.eu-west-1.compute.amazonaws.com/52.49.236.134:22(id=x6spxujti8)]
+       2018-05-14 09:18:58,085 INFO  - TESTNG FAILED: "Default test" - brooklyn.location.blockstore.AbstractVolumeManagerLiveTest.testMoveMountedVolumeToAnotherMachine() finished in 229620 ms
+       org.jclouds.aws.AWSResponseException: request POST https://ec2.eu-west-1.amazonaws.com/ HTTP/1.1 failed with code 400, error: AWSError{requestId='xxxxxxxx-xxxx-xxxx-a4bd-eb2ea0e7d3fe', requestToken='null', code='VolumeInUse', message='vol-01234567890012345 is already attached to an instance', context='{Response=, Errors=}'}
+           at org.jclouds.aws.handlers.ParseAWSErrorFromXmlContent.handleError(ParseAWSErrorFromXmlContent.java:75)
+           at org.jclouds.http.handlers.DelegatingErrorHandler.handleError(DelegatingErrorHandler.java:65)
+           at org.jclouds.http.internal.BaseHttpCommandExecutorService.shouldContinue(BaseHttpCommandExecutorService.java:138)
+           at org.jclouds.http.internal.BaseHttpCommandExecutorService.invoke(BaseHttpCommandExecutorService.java:107)
+           at org.jclouds.rest.internal.InvokeHttpMethod.invoke(InvokeHttpMethod.java:91)
+           at org.jclouds.rest.internal.InvokeHttpMethod.apply(InvokeHttpMethod.java:74)
+           at org.jclouds.rest.internal.InvokeHttpMethod.apply(InvokeHttpMethod.java:45)
+           at org.jclouds.reflect.FunctionalReflection$FunctionalInvocationHandler.handleInvocation(FunctionalReflection.java:117)
+           at com.google.common.reflect.AbstractInvocationHandler.invoke(AbstractInvocationHandler.java:87)
+           at com.sun.proxy.$Proxy70.attachVolumeInRegion(Unknown Source)
+           at brooklyn.location.blockstore.ec2.Ec2VolumeManager.attachBlockDevice(Ec2VolumeManager.java:83)
+           at brooklyn.location.blockstore.AbstractVolumeManager.attachAndMountVolume(AbstractVolumeManager.java:70)
+           at brooklyn.location.blockstore.AbstractVolumeManagerLiveTest.testMoveMountedVolumeToAnotherMachine(AbstractVolumeManagerLiveTest.java:197)
+     */
+    
     // Note we're using the region-name with an explicit availability zone, as is done in the 
     // MarkLogic demo-app so that new VMs will be able to see the existing volumes within that 
     // availability zone.
@@ -30,6 +58,26 @@ public class Ec2VolumeManagerLiveTest extends AbstractVolumeManagerLiveTest {
     // {id=us-east-1/ami-4e32c626, providerId=ami-4e32c626, name=RightImage_CentOS_6.5_x64_v14.0_EBS, location={scope=REGION, id=us-east-1, description=us-east-1, parent=aws-ec2, iso3166Codes=[US-VA]}, os={family=centos, arch=paravirtual, version=5.0, description=411009282317/RightImage_CentOS_6.5_x64_v14.0_EBS, is64Bit=true}, description=RightImage_CentOS_6.5_x64_v14.0_EBS, version=14.0_EBS, status=AVAILABLE[available], loginUser=root, userMetadata={owner=411009282317, rootDeviceType=ebs, virtualizationType=paravirtual, hypervisor=xen}}
     public static final String CENTOS_IMAGE_ID = "eu-west-1/ami-1d841c6a";
     
+    // A copy of super method, except also tests setting volumeType
+    @Test(groups="Live")
+    @Override
+    public void testCreateVolume() throws Exception {
+        // TODO see https://issues.apache.org/jira/browse/JCLOUDS-1417: if you include tags, 
+        // then `describeVolumesInRegion` fails to parse the volume correctly!
+        Map<String, String> tags = ImmutableMap.of(
+                "user", System.getProperty("user.name"),
+                "purpose", "brooklyn-blockstore-VolumeManagerLiveTest");
+        BlockDeviceOptions options = new BlockDeviceOptions()
+                .zone(getDefaultAvailabilityZone())
+                .deviceSuffix(getDefaultDeviceSuffix())
+                .sizeInGb(getVolumeSize())
+                .volumeType("gp2");
+//                .tags(tags);
+        volume = volumeManager.createBlockDevice(jcloudsLocation, options);
+        assertVolumeAvailable(volume);
+        assertVolumeType(volume, "gp2");
+    }
+
     @Override
     protected String getProvider() {
         return PROVIDER;
@@ -59,7 +107,13 @@ public class Ec2VolumeManagerLiveTest extends AbstractVolumeManagerLiveTest {
     protected void assertVolumeAvailable(BlockDevice device) {
         Volume volume = ((Ec2VolumeManager)volumeManager).describeVolume(device);
         assertNotNull(volume);
-        assertEquals(volume.getStatus(), Volume.Status.AVAILABLE);
+        assertEquals(volume.getStatus(), Volume.Status.AVAILABLE, "volume="+volume);
+    }
+
+    
+    protected void assertVolumeType(BlockDevice device, String expectedType) {
+        Volume volume = ((Ec2VolumeManager)volumeManager).describeVolume(device);
+        assertEquals(volume.getVolumeType(), expectedType, "volume="+volume);
     }
 
     @Override


### PR DESCRIPTION
See separate commits:
* replaces tabs with spaces
* tests the volumeType for SSD
* adds config support for iops and encrypted

However, `encrypted` isn't working properly. It looks like the bug reported at https://issues.apache.org/jira/browse/JCLOUDS-1132